### PR TITLE
Add pyobjc requirement to documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,15 +26,16 @@ hello
 Usage on desktop
 ----------------
 
-You need a java JDK installed (openjdk will do), cython, and make to build it
+You need a [Java JDK][] installed (openjdk will do), [cython][], [pyobjc][] and make to 
+build it:
 
     make
 
-That's it! you can run the tests with
+That's it! you can run the tests with:
 
     make tests
 
-To make sure everything is running right.
+to make sure everything is running right.
 
 Usage with python-for-android
 -----------------------------
@@ -116,3 +117,8 @@ Support/Discussion
 ------------------
 
 mailto:pyjnius-dev@googlegroups.com
+
+
+[Java JDK]: http://www.oracle.com/technetwork/java/javase/downloads/index.html
+[cython]: http://www.cython.org/
+[pyobjc]: http://packages.python.org/pyobjc/install.html

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -3,14 +3,15 @@
 Installation
 ============
 
-Pyjnius depends on `Cython <http://cython.org/>`_ and `Java
-<http://www.oracle.com/javase>`_.
+Pyjnius depends on `Cython <http://cython.org/>`_, 
+`PyObjC <http://packages.python.org/pyobjc/install.html>`_, and 
+`Java <http://www.oracle.com/javase>`_.
 
 
 Installation on the Desktop
 ---------------------------
 
-You need the Java JDK and JRE installed (openjdk will do), and Cython. Then,
+You need the Java JDK and JRE installed (openjdk will do), PyObjC, and Cython. Then,
 just type::
 
     sudo python setup.py install
@@ -32,4 +33,3 @@ If you use `Python for android <http://github.com/kivy/python-for-android>`,
 you just need to compile a distribution with the pyjnius module::
 
     ./distribute.sh -m 'pyjnius kivy'
-


### PR DESCRIPTION
On OSX, I had to install PyObjC before I could successfully run `make` to install pyjnius.  This PR notates this requirement in the docs.