### PR TITLE
Issue 96 improved exception handling

### DIFF
--- a/jnius/jnius_export_class.pxi
+++ b/jnius/jnius_export_class.pxi
@@ -2,7 +2,15 @@
 class JavaException(Exception):
     '''Can be a real java exception, or just an exception from the wrapper.
     '''
-    pass
+    classname = None     # The classname of the exception
+    innermessage = None  # The message of the inner exception
+    stacktrace = None    # The stack trace of the inner exception
+
+    def __init__(self, message, classname=None, innermessage=None, stacktrace=None):
+        self.classname = classname
+        self.innermessage = innermessage
+        self.stacktrace = stacktrace
+        Exception.__init__(self, message)
 
 
 cdef class JavaObject(object):

--- a/jnius/jnius_utils.pxi
+++ b/jnius/jnius_utils.pxi
@@ -36,11 +36,20 @@ cdef parse_definition(definition):
 
 
 cdef void check_exception(JNIEnv *j_env) except *:
+    cdef jmethodID toString = NULL
+    cdef jstring e_string
+    cdef jboolean isCopy
     cdef jthrowable exc = j_env[0].ExceptionOccurred(j_env)
     if exc:
         j_env[0].ExceptionDescribe(j_env)
         j_env[0].ExceptionClear(j_env)
-        raise JavaException('JVM exception occured')
+
+        toString = j_env[0].GetMethodID(j_env, j_env[0].FindClass(j_env, "java/lang/Object"), "toString", "()Ljava/lang/String;");
+        e_string = j_env[0].CallObjectMethod(j_env, exc, toString);
+
+        pystr = convert_jobject_to_python(j_env, <bytes> 'Ljava/lang/String;', e_string)
+
+        raise JavaException('JVM exception occurred: ' + pystr)
 
 
 cdef dict assignable_from = {}

--- a/tests/org/jnius/BasicsTest.java
+++ b/tests/org/jnius/BasicsTest.java
@@ -22,6 +22,17 @@ public class BasicsTest {
 	public float methodF() { return 1.23456789f; };
 	public double methodD() { return 1.23456789; };
 	public String methodString() { return new String("helloworld"); }
+	public void methodException(int depth) throws IllegalArgumentException {
+		if (depth == 0) throw new IllegalArgumentException("helloworld");
+		else methodException(depth -1);
+	}
+	public void methodExceptionChained() throws IllegalArgumentException {
+		try {
+			methodException(5);
+		} catch (IllegalArgumentException e) {
+			throw new IllegalArgumentException("helloworld2", e);
+		}
+	}
 
 	static public boolean fieldStaticZ = true;
 	static public byte fieldStaticB = 127;

--- a/tests/test_bad_declaration.py
+++ b/tests/test_bad_declaration.py
@@ -29,4 +29,23 @@ class BadDeclarationTest(unittest.TestCase):
             stack.pop()
             self.fail("Expected exception to be thrown")
         except JavaException as je:
-            self.assertIn("EmptyStackException", str(je))
+            # print "Got JavaException: " + str(je)
+            # print "Got Exception Class: " + je.classname
+            # print "Got stacktrace: \n" + '\n'.join(je.stacktrace)
+            self.assertEquals("java.util.EmptyStackException", je.classname)
+
+    def test_java_exception_chaining(self):
+        BasicsTest = autoclass('org.jnius.BasicsTest')
+        basics = BasicsTest()
+        try:
+            basics.methodExceptionChained()
+            self.fail("Expected exception to be thrown")
+        except JavaException as je:
+            # print "Got JavaException: " + str(je)
+            # print "Got Exception Class: " + je.classname
+            # print "Got Exception Message: " + je.innermessage
+            # print "Got stacktrace: \n" + '\n'.join(je.stacktrace)
+            self.assertEquals("java.lang.IllegalArgumentException", je.classname)
+            self.assertEquals("helloworld2", je.innermessage)
+            self.assertIn("Caused by:", je.stacktrace)
+            self.assertEquals(11, len(je.stacktrace))

--- a/tests/test_bad_declaration.py
+++ b/tests/test_bad_declaration.py
@@ -21,3 +21,12 @@ class BadDeclarationTest(unittest.TestCase):
         Stack = autoclass('java.util.Stack')
         stack = Stack()
         self.assertRaises(JavaException, stack.push, 'hello', 'world', 123)
+
+    def test_java_exception_handling(self):
+        Stack = autoclass('java.util.Stack')
+        stack = Stack()
+        try:
+            stack.pop()
+            self.fail("Expected exception to be thrown")
+        except JavaException as je:
+            self.assertIn("EmptyStackException", str(je))


### PR DESCRIPTION
I initially applied just the patch that is described in #96, but then wanted to go further -- primarily so that on the python side I can distinguish between exception types and decide whether to locally handle the exception or whether to propagate the exception up (perhaps with exception rewrapping).
