### PR TITLE
Followup fixes for python 3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ before_install:
   - sudo apt-get install python-pip openjdk-7-jdk
 
 install:
-  - pip install --upgrade cython future six
+  - pip install --upgrade cython six
 
 script:
   - make

--- a/tests/test_assignable.py
+++ b/tests/test_assignable.py
@@ -1,8 +1,6 @@
 from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
 import unittest
 from jnius import autoclass, JavaException
 

--- a/tests/test_bad_declaration.py
+++ b/tests/test_bad_declaration.py
@@ -1,8 +1,6 @@
 from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
 import unittest
 from jnius import JavaException, JavaClass
 from jnius.reflect import autoclass

--- a/tests/test_basics.py
+++ b/tests/test_basics.py
@@ -1,8 +1,6 @@
 from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
 import unittest
 from jnius.reflect import autoclass
 

--- a/tests/test_bytearray.py
+++ b/tests/test_bytearray.py
@@ -1,8 +1,6 @@
 from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
 import unittest
 from jnius import autoclass
 

--- a/tests/test_cast.py
+++ b/tests/test_cast.py
@@ -1,8 +1,6 @@
 from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
 import unittest
 from jnius.reflect import autoclass
 from jnius import cast

--- a/tests/test_class_argument.py
+++ b/tests/test_class_argument.py
@@ -1,8 +1,6 @@
 from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
 import unittest
 from jnius.reflect import autoclass
 

--- a/tests/test_enum.py
+++ b/tests/test_enum.py
@@ -1,8 +1,6 @@
 from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
 import unittest
 
 from jnius.reflect import autoclass

--- a/tests/test_implementation.py
+++ b/tests/test_implementation.py
@@ -2,8 +2,6 @@
 from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
 import unittest
 from jnius.reflect import autoclass
 

--- a/tests/test_interface.py
+++ b/tests/test_interface.py
@@ -1,8 +1,6 @@
 from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
 import unittest
 
 from jnius import autoclass, JavaException

--- a/tests/test_jnitable_overflow.py
+++ b/tests/test_jnitable_overflow.py
@@ -1,8 +1,6 @@
 from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
 # run it, and check with Java VisualVM if we are eating too much memory or not!
 if __name__ == '__main__':
     from jnius import autoclass

--- a/tests/test_method_multiple_signatures.py
+++ b/tests/test_method_multiple_signatures.py
@@ -1,8 +1,6 @@
 from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
 import unittest
 from jnius.reflect import autoclass
 

--- a/tests/test_multidimension.py
+++ b/tests/test_multidimension.py
@@ -1,8 +1,6 @@
 from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
 import unittest
 from jnius.reflect import autoclass
 

--- a/tests/test_output_args.py
+++ b/tests/test_output_args.py
@@ -1,8 +1,6 @@
 from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
 import unittest
 from jnius import autoclass
 

--- a/tests/test_proxy.py
+++ b/tests/test_proxy.py
@@ -1,10 +1,8 @@
 from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
-from builtins import super
-from future import standard_library
-standard_library.install_aliases()
-from builtins import range
+from six.moves import range
+
 from jnius import autoclass, java_method, PythonJavaClass, cast
 from nose.tools import *
 

--- a/tests/test_reflect.py
+++ b/tests/test_reflect.py
@@ -1,8 +1,6 @@
 from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
 import unittest
 from jnius.reflect import autoclass
 

--- a/tests/test_simple.py
+++ b/tests/test_simple.py
@@ -1,11 +1,9 @@
 from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
 import unittest
 from jnius import JavaClass, MetaJavaClass, JavaMethod
-from future.utils import with_metaclass
+from six import with_metaclass
 
 class HelloWorldTest(unittest.TestCase):
 


### PR DESCRIPTION
* stop using `future` except in tests, use `six` instead
* fix py2 vs py3 issues with `decode` in `setup.py`, might fix windows. Might fix android.