### PR TITLE
setup: fixed invalid libjvm.so reference on i386 cpu

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -129,7 +129,7 @@ else:
         libraries = ['jvm']
     else:
         incl_dir = join(jdk_home, 'include', 'linux')
-        lib_location = 'jre/lib/amd64/server/libjvm.so'
+        lib_location = 'jre/lib/{}/server/libjvm.so'.format(cpu)
 
     include_dirs = [
             join(jdk_home, 'include'),


### PR DESCRIPTION
Issue reported here: https://github.com/kivy/pyjnius/issues/192

The provided patch worked for me on CentOS, Ubuntu e Debian. It would be cool to have it included in the official release.