### PR TITLE
Updated readme to counter issues #197

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,11 @@ Usage on desktop
 ----------------
 
 You need a java JDK installed (OpenJDK will do), Cython and make to build it.
+Please ensure that your `JDK_HOME` or `JAVA_HOME` environment variable points
+to the installed JDK root directory, and that the JVM library (`jvm.so` or
+`jvm.dll`) is available from your `PATH` environment variable. **Failure to do
+so may result in a failed install, or a successful install but inability to
+use the pyjnius library.**
 
     make
 


### PR DESCRIPTION
Readme.md now tells users to ensure that their `PATH` and `JAVA_HOME` (or `JDK_HOME`) environment variables must be set properly in order to ensure the successful usage of PyJNIus. This should help counter issues #197 -- not the most automated fix, but still.

Apologies for the triple commit, apparently I don't know how to use markdown properly :)