### PR TITLE
for...in iteration of list interfaces

### DIFF
--- a/jnius/reflect.py
+++ b/jnius/reflect.py
@@ -223,7 +223,10 @@ def autoclass(clsname):
         try:
             return self.get(index)
         except JavaException as e:
-            if e.classname == "java.lang.IndexOutOfBoundsException":
+            # initialize the subclass before getting the Class.forName
+            # otherwise isInstance does not know of the subclass
+            mock_exception_object = autoclass(e.classname)()
+            if Class.forName("java.lang.IndexOutOfBoundsException").isInstance(mock_exception_object):
                 # python for...in iteration checks for end of list by waiting for IndexError
                 raise IndexError()
             else:

--- a/tests/test_reflect.py
+++ b/tests/test_reflect.py
@@ -14,3 +14,10 @@ class ReflectTest(unittest.TestCase):
         stack.push('world')
         self.assertEqual(stack.pop(), 'world')
         self.assertEqual(stack.pop(), 'hello')
+
+    def test_list_iteration(self):
+        ArrayList = autoclass('java.util.ArrayList')
+        words = ArrayList()
+        words.add('hello')
+        words.add('world')
+        self.assertEqual(['hello', 'world'], [word for word in words])


### PR DESCRIPTION
Throw index error instead of OutOfBoundsError, allowing us to use for...in with List interfaces.

https://docs.python.org/3.7/reference/datamodel.html#object.__getitem__