### PR TITLE
Switching to JNI UTF-16 API for strings to fix supplementary unicode char encoding

### DIFF
--- a/tests/java-src/org/jnius/BasicsTest.java
+++ b/tests/java-src/org/jnius/BasicsTest.java
@@ -11,7 +11,7 @@ public class BasicsTest {
 	static public long methodStaticJ() { return 9223372036854775807L; };
 	static public float methodStaticF() { return 1.23456789f; };
 	static public double methodStaticD() { return 1.23456789; };
-	static public String methodStaticString() { return new String("helloworld"); }
+	static public String methodStaticString() { return new String("hello \uD83C\uDF0E!"); }
 
 	public boolean methodZ() { return true; };
 	public byte methodB() { return 127; };
@@ -21,9 +21,9 @@ public class BasicsTest {
 	public long methodJ() { return 9223372036854775807L; };
 	public float methodF() { return 1.23456789f; };
 	public double methodD() { return 1.23456789; };
-	public String methodString() { return new String("helloworld"); }
+	public String methodString() { return new String("hello \uD83C\uDF0E!"); }
 	public void methodException(int depth) throws IllegalArgumentException {
-		if (depth == 0) throw new IllegalArgumentException("helloworld");
+		if (depth == 0) throw new IllegalArgumentException("hello \uD83C\uDF0E!");
 		else methodException(depth -1);
 	}
 	public void methodExceptionChained() throws IllegalArgumentException {
@@ -42,7 +42,7 @@ public class BasicsTest {
 	static public long fieldStaticJ = 9223372036854775807L;
 	static public float fieldStaticF = 1.23456789f;
 	static public double fieldStaticD = 1.23456789;
-	static public String fieldStaticString = new String("helloworld");
+	static public String fieldStaticString = new String("hello \uD83C\uDF0E!");
 
 	public boolean fieldZ = true;
 	public byte fieldB = 127;
@@ -52,7 +52,7 @@ public class BasicsTest {
 	public long fieldJ = 9223372036854775807L;
 	public float fieldF = 1.23456789f;
 	public double fieldD = 1.23456789;
-	public String fieldString = new String("helloworld");
+	public String fieldString = new String("hello \uD83C\uDF0E!");
 
 	public boolean fieldSetZ;
 	public byte fieldSetB;
@@ -114,7 +114,7 @@ public class BasicsTest {
 	};
 	public String[] methodArrayString() {
 		String[] x = new String[3];
-		x[0] = x[1] = x[2] = new String("helloworld");
+		x[0] = x[1] = x[2] = new String("hello \uD83C\uDF0E!");
 		return x;
 	};
 
@@ -128,7 +128,7 @@ public class BasicsTest {
 	}
 
 	public boolean methodParamsString(String s) {
-		return (s.equals("helloworld"));
+		return (s.equals("hello \uD83C\uDF0E!"));
 	}
 
 	public boolean methodParamsArrayI(int[] x) {
@@ -140,7 +140,7 @@ public class BasicsTest {
 	public boolean methodParamsArrayString(String[] x) {
 		if (x.length != 2)
 			return false;
-		return (x[0].equals("hello") && x[1].equals("world"));
+		return (x[0].equals("hello") && x[1].equals("\uD83C\uDF0E"));
 	}
 
 	public boolean methodParamsObject(Object x) {
@@ -150,7 +150,7 @@ public class BasicsTest {
 	public Object methodReturnStrings() {
 		String[] hello_world = new String[2];
 		hello_world[0] = "Hello";
-		hello_world[1] = "world";
+		hello_world[1] = "\uD83C\uDF0E";
 		return hello_world;
 	}
 

--- a/tests/test_basics.py
+++ b/tests/test_basics.py
@@ -1,8 +1,14 @@
 from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
+import sys
 import unittest
 from jnius.reflect import autoclass
+
+def py2_encode(uni):
+    if sys.version_info < (3, 0):
+        uni = uni.encode('utf-8')
+    return uni
 
 class BasicsTest(unittest.TestCase):
 
@@ -16,7 +22,7 @@ class BasicsTest(unittest.TestCase):
         self.assertEquals(Test.methodStaticJ(), 9223372036854775807)
         self.assertAlmostEquals(Test.methodStaticF(), 1.23456789)
         self.assertEquals(Test.methodStaticD(), 1.23456789)
-        self.assertEquals(Test.methodStaticString(), 'helloworld')
+        self.assertEquals(Test.methodStaticString(), py2_encode(u'hello \U0001F30E!'))
 
     def test_static_fields(self):
         Test = autoclass('org.jnius.BasicsTest')
@@ -28,7 +34,7 @@ class BasicsTest(unittest.TestCase):
         self.assertEquals(Test.fieldStaticJ, 9223372036854775807)
         self.assertAlmostEquals(Test.fieldStaticF, 1.23456789)
         self.assertEquals(Test.fieldStaticD, 1.23456789)
-        self.assertEquals(Test.fieldStaticString, 'helloworld')
+        self.assertEquals(Test.fieldStaticString, py2_encode(u'hello \U0001F30E!'))
 
     def test_instance_methods(self):
         test = autoclass('org.jnius.BasicsTest')()
@@ -40,7 +46,7 @@ class BasicsTest(unittest.TestCase):
         self.assertEquals(test.methodJ(), 9223372036854775807)
         self.assertAlmostEquals(test.methodF(), 1.23456789)
         self.assertEquals(test.methodD(), 1.23456789)
-        self.assertEquals(test.methodString(), 'helloworld')
+        self.assertEquals(test.methodString(), py2_encode(u'hello \U0001F30E!'))
 
     def test_instance_fields(self):
         test = autoclass('org.jnius.BasicsTest')()
@@ -52,7 +58,7 @@ class BasicsTest(unittest.TestCase):
         self.assertEquals(test.fieldJ, 9223372036854775807)
         self.assertAlmostEquals(test.fieldF, 1.23456789)
         self.assertEquals(test.fieldD, 1.23456789)
-        self.assertEquals(test.fieldString, 'helloworld')
+        self.assertEquals(test.fieldString, py2_encode(u'hello \U0001F30E!'))
         test2 = autoclass('org.jnius.BasicsTest')(10)
         self.assertEquals(test2.fieldB, 10)
         self.assertEquals(test.fieldB, 127)
@@ -95,16 +101,16 @@ class BasicsTest(unittest.TestCase):
         self.assertAlmostEquals(ret[2], ref[2])
 
         self.assertEquals(test.methodArrayD(), [1.23456789] * 3)
-        self.assertEquals(test.methodArrayString(), ['helloworld'] * 3)
+        self.assertEquals(test.methodArrayString(), [py2_encode(u'hello \U0001F30E!')] * 3)
 
     def test_instances_methods_params(self):
         test = autoclass('org.jnius.BasicsTest')()
         self.assertEquals(test.methodParamsZBCSIJFD(
             True, 127, 'k', 32767, 2147483467, 9223372036854775807, 1.23456789, 1.23456789), True)
-        self.assertEquals(test.methodParamsString('helloworld'), True)
+        self.assertEquals(test.methodParamsString(py2_encode(u'hello \U0001F30E!')), True)
         self.assertEquals(test.methodParamsArrayI([1, 2, 3]), True)
         self.assertEquals(test.methodParamsArrayString([
-            'hello', 'world']), True)
+            py2_encode(u'hello'), py2_encode(u'\U0001F30E')]), True)
 
     def test_instances_methods_params_object_list_str(self):
         test = autoclass('org.jnius.BasicsTest')()
@@ -131,7 +137,8 @@ class BasicsTest(unittest.TestCase):
 
     def test_return_array_as_object_array_of_strings(self):
         test = autoclass('org.jnius.BasicsTest')()
-        self.assertEquals(test.methodReturnStrings(), ['Hello', 'world'])
+        self.assertEquals(test.methodReturnStrings(), [py2_encode(u'Hello'),
+                py2_encode(u'\U0001F30E')])
 
     def test_return_array_as_object_of_integers(self):
         test = autoclass('org.jnius.BasicsTest')()

--- a/tests/test_implementation.py
+++ b/tests/test_implementation.py
@@ -2,6 +2,7 @@
 from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
+import sys
 import unittest
 from jnius.reflect import autoclass
 
@@ -22,3 +23,12 @@ class ImplementationTest(unittest.TestCase):
     def test_unicode(self):
         System = autoclass('java.lang.System')
         System.out.printf(u'é')
+
+        Stack = autoclass('java.util.Stack')
+        stack = Stack()
+        emoji = u'\U0001F602'
+        stack.push(emoji)
+        popped = stack.pop()
+        if sys.version_info < (3, 0):
+            popped = popped.decode('utf-8')
+        self.assertEquals(emoji, popped)


### PR DESCRIPTION
Fix for #284

Switched all string creation/decoding to use the JNI UTF-16 api for unicode rather than try to wrangle with JNI's modified UTF-8 encoding.

I kept the existing assumption for Python 2 that byte strings are UTF-8 encoded.