### PR TITLE
Fixed issue #279 which causes callbacks to fail in Windows 64 bit

### DIFF
--- a/jnius/jnius_proxy.pxi
+++ b/jnius/jnius_proxy.pxi
@@ -162,7 +162,7 @@ cdef create_proxy_instance(JNIEnv *j_env, py_obj, j_interfaces, javacontext):
     # convert strings to Class
     j_interfaces = [find_javaclass(x) for x in j_interfaces]
 
-    cdef JavaClass nih = NativeInvocationHandler(<long><void *>py_obj)
+    cdef JavaClass nih = NativeInvocationHandler(<long long><void *>py_obj)
     cdef JNINativeMethod invoke_methods[1]
     invoke_methods[0].name = 'invoke0'
     invoke_methods[0].signature = '(Ljava/lang/Object;Ljava/lang/reflect/Method;[Ljava/lang/Object;)Ljava/lang/Object;'


### PR DESCRIPTION
The issue #279 was caused due to invalid casting from c++ _long long_ to c++ _long_. This caused the value of variable _ptr_ of java class _NativeInvocationHandler_ become invalid (due to loss of precision by casting) causing _Access Violation Exception_ in Windows. The above exception is experienced during callbacks.

The issue was fixed by correcting cast _long_ to _long long_.