### PR TITLE
Fixed mishandling of long arguments in multiple methods. Added test cases.

### DIFF
--- a/jnius/jnius_utils.pxi
+++ b/jnius/jnius_utils.pxi
@@ -264,9 +264,19 @@ cdef int calculate_score(sign_args, args, is_varargs=False) except *:
             score += 10
             continue
 
-        if r == 'S' or r == 'I' or r == 'J':
+        if r == 'S' or r == 'I':
             if isinstance(arg, int) or (
                     (isinstance(arg, long) and arg < 2 ** 31)):
+                score += 10
+                continue
+            elif isinstance(arg, float):
+                score += 5
+                continue
+            else:
+                return -1
+
+        if r == 'J':
+            if isinstance(arg, int) or isinstance(arg, long):
                 score += 10
                 continue
             elif isinstance(arg, float):

--- a/jnius/jnius_utils.pxi
+++ b/jnius/jnius_utils.pxi
@@ -265,7 +265,8 @@ cdef int calculate_score(sign_args, args, is_varargs=False) except *:
             continue
 
         if r == 'S' or r == 'I' or r == 'J':
-            if isinstance(arg, int):
+            if isinstance(arg, int) or (
+                    (isinstance(arg, long) and arg < 2 ** 31)):
                 score += 10
                 continue
             elif isinstance(arg, float):

--- a/jnius/jnius_utils.pxi
+++ b/jnius/jnius_utils.pxi
@@ -266,7 +266,7 @@ cdef int calculate_score(sign_args, args, is_varargs=False) except *:
 
         if r == 'S' or r == 'I':
             if isinstance(arg, int) or (
-                    (isinstance(arg, long) and arg < 2 ** 31)):
+                    (isinstance(arg, long) and arg < 2147483648)):
                 score += 10
                 continue
             elif isinstance(arg, float):

--- a/tests/java-src/org/jnius/MultipleMethods.java
+++ b/tests/java-src/org/jnius/MultipleMethods.java
@@ -29,4 +29,8 @@ public class MultipleMethods {
     public static String resolve(int... integers) {
 	return "resolved varargs";
     }
+
+    public static String resolve(int i, long j, String k) {
+    return "resolved one int, one long and a string";
+    }
 }

--- a/tests/test_basics.py
+++ b/tests/test_basics.py
@@ -101,6 +101,8 @@ class BasicsTest(unittest.TestCase):
         test = autoclass('org.jnius.BasicsTest')()
         self.assertEquals(test.methodParamsZBCSIJFD(
             True, 127, 'k', 32767, 2147483467, 9223372036854775807, 1.23456789, 1.23456789), True)
+        self.assertEquals(test.methodParamsZBCSIJFD(
+            True, 127L, 'k', 32767L, 2147483467L, 9223372036854775807, 1.23456789, 1.23456789), True)
         self.assertEquals(test.methodParamsString('helloworld'), True)
         self.assertEquals(test.methodParamsArrayI([1, 2, 3]), True)
         self.assertEquals(test.methodParamsArrayString([

--- a/tests/test_basics.py
+++ b/tests/test_basics.py
@@ -4,6 +4,13 @@ from __future__ import absolute_import
 import unittest
 from jnius.reflect import autoclass
 
+try:
+    long
+except NameError:
+    # Python 3
+    long = int
+
+
 class BasicsTest(unittest.TestCase):
 
     def test_static_methods(self):
@@ -102,7 +109,7 @@ class BasicsTest(unittest.TestCase):
         self.assertEquals(test.methodParamsZBCSIJFD(
             True, 127, 'k', 32767, 2147483467, 9223372036854775807, 1.23456789, 1.23456789), True)
         self.assertEquals(test.methodParamsZBCSIJFD(
-            True, 127L, 'k', 32767L, 2147483467L, 9223372036854775807, 1.23456789, 1.23456789), True)
+            True, long(127), 'k', long(32767), long(2147483467), 9223372036854775807, 1.23456789, 1.23456789), True)
         self.assertEquals(test.methodParamsString('helloworld'), True)
         self.assertEquals(test.methodParamsArrayI([1, 2, 3]), True)
         self.assertEquals(test.methodParamsArrayString([

--- a/tests/test_method_multiple_signatures.py
+++ b/tests/test_method_multiple_signatures.py
@@ -4,6 +4,13 @@ from __future__ import absolute_import
 import unittest
 from jnius.reflect import autoclass
 
+try:
+    long
+except NameError:
+    # Python 3
+    long = int
+
+
 class MultipleSignature(unittest.TestCase):
 
     def test_multiple_constructors(self):
@@ -46,7 +53,7 @@ class MultipleSignature(unittest.TestCase):
 
     def test_multiple_methods_varargs_long(self):
         MultipleMethods = autoclass('org.jnius.MultipleMethods')
-        self.assertEqual(MultipleMethods.resolve(1L, 2L, 3L), 'resolved varargs')
+        self.assertEqual(MultipleMethods.resolve(long(1), long(2), long(3)), 'resolved varargs')
 
     def test_multiple_methods_two_args_and_varargs(self):
         MultipleMethods = autoclass('org.jnius.MultipleMethods')
@@ -55,7 +62,7 @@ class MultipleSignature(unittest.TestCase):
     def test_multiple_methods_one_int_one_small_long_and_a_string(self):
         MultipleMethods = autoclass('org.jnius.MultipleMethods')
         self.assertEqual(MultipleMethods.resolve(
-            1, 1L, "one"), "resolved one int, one long and a string")
+            1, long(1), "one"), "resolved one int, one long and a string")
 
     def test_multiple_methods_one_int_one_actual_long_and_a_string(self):
         MultipleMethods = autoclass('org.jnius.MultipleMethods')

--- a/tests/test_method_multiple_signatures.py
+++ b/tests/test_method_multiple_signatures.py
@@ -44,6 +44,20 @@ class MultipleSignature(unittest.TestCase):
         MultipleMethods = autoclass('org.jnius.MultipleMethods')
         self.assertEqual(MultipleMethods.resolve(1, 2, 3), 'resolved varargs')
 
+    def test_multiple_methods_varargs_long(self):
+        MultipleMethods = autoclass('org.jnius.MultipleMethods')
+        self.assertEqual(MultipleMethods.resolve(1L, 2L, 3L), 'resolved varargs')
+
     def test_multiple_methods_two_args_and_varargs(self):
         MultipleMethods = autoclass('org.jnius.MultipleMethods')
         self.assertEqual(MultipleMethods.resolve('one', 'two', 1, 2, 3), 'resolved two args and varargs')
+
+    def test_multiple_methods_one_int_one_small_long_and_a_string(self):
+        MultipleMethods = autoclass('org.jnius.MultipleMethods')
+        self.assertEqual(MultipleMethods.resolve(
+            1, 1L, "one"), "resolved one int, one long and a string")
+
+    def test_multiple_methods_one_int_one_actual_long_and_a_string(self):
+        MultipleMethods = autoclass('org.jnius.MultipleMethods')
+        self.assertEqual(MultipleMethods.resolve(
+            1, 2 ** 63 - 1, "one"), "resolved one int, one long and a string")


### PR DESCRIPTION
It was not possible to pass actual long values to multiple methods. It made it impossible to call AlarmManger.set in android, for instance.

Test cases are included.