### PR TITLE
Fix bad JavaException in _getitem

### DIFF
--- a/jnius/jnius_conversion.pxi
+++ b/jnius/jnius_conversion.pxi
@@ -110,6 +110,16 @@ cdef void populate_args(JNIEnv *j_env, tuple definition_args, jvalue *j_args, ar
                     j_env, argtype[1:], py_arg)
 
 
+cdef convert_jstring_to_python(JNIEnv *j_env, jstring string):
+    c_str = <char *>j_env[0].GetStringUTFChars(j_env, string, NULL)
+    py_str = <bytes>c_str
+    j_env[0].ReleaseStringUTFChars(j_env, string, c_str)
+    if PY_MAJOR_VERSION < 3:
+        return py_str
+    else:
+        return py_str.decode('utf-8')
+
+
 cdef convert_jobject_to_python(JNIEnv *j_env, definition, jobject j_object):
     # Convert a Java Object to a Python object, according to the definition.
     # If the definition is a java/lang/Object, then try to determine what is it
@@ -144,15 +154,7 @@ cdef convert_jobject_to_python(JNIEnv *j_env, definition, jobject j_object):
             string = <jstring> (j_env[0].CallObjectMethod(j_env, j_object, retmeth))
         else:
             string = <jstring>j_object
-        c_str = <char *>j_env[0].GetStringUTFChars(j_env, string, NULL)
-        py_str = <bytes>c_str
-        j_env[0].ReleaseStringUTFChars(j_env, string, c_str)
-
-
-        if PY_MAJOR_VERSION < 3:
-            return py_str
-        else:
-            return py_str.decode('utf-8')
+        return convert_jstring_to_python(j_env, string)
 
     # XXX should be deactivable from configuration
     # ie, user might not want autoconvertion of lang classes.

--- a/jnius/jnius_utils.pxi
+++ b/jnius/jnius_utils.pxi
@@ -77,7 +77,7 @@ cdef void check_exception(JNIEnv *j_env) except *:
         getStackTrace = j_env[0].GetMethodID(j_env, cls_throwable, "getStackTrace", "()[Ljava/lang/StackTraceElement;");
 
         e_msg = j_env[0].CallObjectMethod(j_env, exc, getMessage);
-        pymsg = None if e_msg == NULL else convert_jobject_to_python(j_env, <bytes> 'Ljava/lang/String;', e_msg)
+        pymsg = None if e_msg == NULL else convert_jstring_to_python(j_env, e_msg)
 
         pystack = []
         _append_exception_trace_messages(j_env, pystack, exc, getCause, getStackTrace, toString)

--- a/jnius/reflect.py
+++ b/jnius/reflect.py
@@ -226,7 +226,7 @@ def autoclass(clsname):
             # initialize the subclass before getting the Class.forName
             # otherwise isInstance does not know of the subclass
             mock_exception_object = autoclass(e.classname)()
-            if Class.forName("java.lang.IndexOutOfBoundsException").isInstance(mock_exception_object):
+            if find_javaclass("java.lang.IndexOutOfBoundsException").isInstance(mock_exception_object):
                 # python for...in iteration checks for end of list by waiting for IndexError
                 raise IndexError()
             else:


### PR DESCRIPTION
Fix list iteration test broken since commit efe610b8, which results in a
JavaException with a bad message being thrown.  This was caused by the call to
'Class.forName', which throws the exception.