### PR TITLE
Add missing NativeInvocationHandler

### DIFF
--- a/jnius/jnius_jvm_desktop.pxi
+++ b/jnius/jnius_jvm_desktop.pxi
@@ -29,7 +29,7 @@ cdef void create_jnienv() except *:
 
     optarr = jnius_config.options
     cp = jnius_config.expand_classpath()
-    optarr.append("-Djava.class.path={0}".format(cp).encode())
+    optarr.append("-Djava.class.path={0}".format(cp))
 
     options = <JavaVMOption*>malloc(sizeof(JavaVMOption) * len(optarr))
     for i, opt in enumerate(optarr):

--- a/jnius/jnius_jvm_desktop.pxi
+++ b/jnius/jnius_jvm_desktop.pxi
@@ -28,7 +28,8 @@ cdef void create_jnienv() except *:
     import jnius_config
 
     optarr = jnius_config.options
-    optarr.append("-Djava.class.path=" + jnius_config.expand_classpath())
+    cp = jnius_config.expand_classpath()
+    optarr.append("-Djava.class.path={0}".format(cp).encode())
 
     options = <JavaVMOption*>malloc(sizeof(JavaVMOption) * len(optarr))
     for i, opt in enumerate(optarr):

--- a/jnius_config.py
+++ b/jnius_config.py
@@ -64,13 +64,20 @@ def get_classpath():
     from os.path import realpath
     global classpath
 
+    # add a path to java classes packaged with jnius
+    from pkg_resources import resource_filename
+    return_classpath = [realpath(resource_filename(__name__, 'jnius/src'))]
+
     if classpath is not None:
-        return list(classpath)
+        return_classpath = classpath + return_classpath
 
-    if 'CLASSPATH' in environ:
-        return environ['CLASSPATH'].split(split_char)
+    elif 'CLASSPATH' in environ:
+        return_classpath = environ['CLASSPATH'].split(split_char) + return_classpath
 
-    return [realpath('.')]
+    else:
+        return_classpath = [realpath('.')] + return_classpath
+
+    return return_classpath
 
 
 def expand_classpath():

--- a/setup.py
+++ b/setup.py
@@ -3,6 +3,10 @@ try:
     from setuptools import setup, Extension
 except ImportError:
     from distutils.core import setup, Extension
+try:
+    import subprocess32 as subprocess
+except ImportError:
+    import subprocess
 from os import environ
 from os.path import dirname, join, exists
 import sys
@@ -69,7 +73,6 @@ if platform == 'android':
     libraries = ['sdl', 'log']
     library_dirs = ['libs/' + getenv('ARCH')]
 elif platform == 'darwin':
-    import subprocess
     framework = subprocess.Popen(
         '/usr/libexec/java_home',
         stdout=subprocess.PIPE, shell=True).communicate()[0]
@@ -89,7 +92,6 @@ elif platform == 'darwin':
             '{0}/include/darwin'.format(framework)
         ]
 else:
-    import subprocess
     # otherwise, we need to search the JDK_HOME
     jdk_home = getenv('JDK_HOME')
     if not jdk_home:
@@ -166,6 +168,12 @@ with open(join(dirname(__file__), 'jnius', 'config.pxi'), 'w') as fd:
 with open(join('jnius', '__init__.py')) as fd:
     versionline = [x for x in fd.readlines() if x.startswith('__version__')]
     version = versionline[0].split("'")[-2]
+
+# Compile NativeInvocationHandler.java
+subprocess.check_call([
+    'javac',
+    join('jnius', 'src', 'org', 'jnius', 'NativeInvocationHandler.java')
+])
 
 # create the extension
 setup(

--- a/setup.py
+++ b/setup.py
@@ -171,7 +171,7 @@ with open(join('jnius', '__init__.py')) as fd:
 
 # Compile NativeInvocationHandler.java
 subprocess.check_call([
-    'javac',
+    'javac', '-target', '1.6', '-source', '1.6',
     join('jnius', 'src', 'org', 'jnius', 'NativeInvocationHandler.java')
 ])
 

--- a/setup.py
+++ b/setup.py
@@ -190,6 +190,9 @@ setup(
             extra_link_args=extra_link_args
         )
     ],
+    package_data={
+        'jnius': [ 'src/org/jnius/*' ]
+    },
     classifiers=[
         'Development Status :: 4 - Beta',
         'Intended Audience :: Developers',


### PR DESCRIPTION
This PR closes #288, #223, and #137, the various issues complaining that the NativeInvocationHandler is missing in the `pip install`ed version of pyjnius.

It cherry-picks @jessecrossen's [26f1367a](https://github.com/kivy/pyjnius/commit/26f1367ab143cd72203f0db77556279eac8c304f) referenced in #137 to include the NativeInvocationHandler's folder in the pip package and adjust the classpath accordingly, and adds a `subprocess.check_call` to `javac` to actually build the `.class` file.

Tested so far on:
- Ubuntu Xenial (openjdk8, py2)
- ArchLinux (openjdk8, py3)
- Windows 10 (oracle jdk 8, Anaconda Python 3.6.3)
