### PR TITLE
Fix traceback.print_exc call

### DIFF
--- a/jnius/jnius_proxy.pxi
+++ b/jnius/jnius_proxy.pxi
@@ -46,8 +46,8 @@ cdef class PythonJavaClass(object):
         try:
             ret = self._invoke(method, *args)
             return ret
-        except Exception as e:
-            traceback.print_exc(e)
+        except Exception:
+            traceback.print_exc()
             return None
 
     def _invoke(self, method, *args):
@@ -141,16 +141,16 @@ cdef jobject py_invoke0(JNIEnv *j_env, jobject j_this, jobject j_proxy, jobject
 
     try:
         return convert_python_to_jobject(j_env, jtype or ret_signature, ret)
-    except Exception as e:
-        traceback.print_exc(e)
+    except Exception:
+        traceback.print_exc()
 
 
 cdef jobject invoke0(JNIEnv *j_env, jobject j_this, jobject j_proxy, jobject
         j_method, jobjectArray args) with gil:
     try:
         return py_invoke0(j_env, j_this, j_proxy, j_method, args)
-    except Exception as e:
-        traceback.print_exc(e)
+    except Exception:
+        traceback.print_exc()
         return NULL
 
 # now we need to create a proxy and pass it an invocation handler


### PR DESCRIPTION
`traceback.print_exc` expects `limit` as a first argument. Passing
excepiton instance (AssertionError in example below) raises TypeError
inside of traceback module:
```
TypeError: unorderable types: AssertionError() >= int()
```