### PR TITLE
Remove earlier (pre-utf16) implementation of convert_jstring_to_python

### DIFF
--- a/jnius/jnius_conversion.pxi
+++ b/jnius/jnius_conversion.pxi
@@ -105,16 +105,6 @@ cdef void populate_args(JNIEnv *j_env, tuple definition_args, jvalue *j_args, ar
                     j_env, argtype[1:], py_arg)
 
 
-cdef convert_jstring_to_python(JNIEnv *j_env, jstring string):
-    c_str = <char *>j_env[0].GetStringUTFChars(j_env, string, NULL)
-    py_str = <bytes>c_str
-    j_env[0].ReleaseStringUTFChars(j_env, string, c_str)
-    if PY_MAJOR_VERSION < 3:
-        return py_str
-    else:
-        return py_str.decode('utf-8')
-
-
 cdef convert_jobject_to_python(JNIEnv *j_env, definition, jobject j_object):
     # Convert a Java Object to a Python object, according to the definition.
     # If the definition is a java/lang/Object, then try to determine what is it


### PR DESCRIPTION
The recently merged PRs #285 and #303 both add a function called `convert_jstring_to_python`. The duplication is preventing current master from compiling. This PR resolves that conflict in favor of the #285 version, which is the one that works on recent cythons with the new encoding behavior.