### PR TITLE
Only remove 2 characters from field names when method begins with "is"

### DIFF
--- a/jnius/reflect.py
+++ b/jnius/reflect.py
@@ -186,7 +186,7 @@ def autoclass(clsname):
             cls = JavaStaticMethod if static else JavaMethod
             classDict[name] = cls(sig, varargs=varargs)
             if name != 'getClass' and bean_getter(name) and len(method.getParameterTypes()) == 0:
-                lowername = lower_name(name[3:])
+                lowername = lower_name(name[2 if name.startswith('is') else 3:])
                 classDict[lowername] = (lambda n: property(lambda self: getattr(self, n)()))(name)
             continue
 

--- a/tests/java-src/org/jnius/BasicsTest.java
+++ b/tests/java-src/org/jnius/BasicsTest.java
@@ -33,6 +33,8 @@ public class BasicsTest {
 			throw new IllegalArgumentException("helloworld2", e);
 		}
 	}
+    public boolean getDisabled() { return true; };
+    public boolean isEnabled() { return !this.getDisabled(); };
 
 	static public boolean fieldStaticZ = true;
 	static public byte fieldStaticB = 127;

--- a/tests/test_basics.py
+++ b/tests/test_basics.py
@@ -71,6 +71,11 @@ class BasicsTest(unittest.TestCase):
         self.assertEquals(test.fieldB, 127)
         self.assertEquals(test2.fieldB, 10)
 
+    def test_instance_getter_naming(self):
+        test = autoclass('org.jnius.BasicsTest')()
+        self.assertEquals(test.disabled, True)
+        self.assertEquals(test.enabled, False)
+
     def test_instance_set_fields(self):
         test = autoclass('org.jnius.BasicsTest')()
         test.fieldSetZ = True


### PR DESCRIPTION
Field names generated from getter method names beginning with "is" have the first character chomped off (ie. ```Class.isEnabled()``` becomes ```Class.nabled```). This PR adds a check to determine slice size. Test case included.