### PR TITLE
Bugfix for: 'can only concatenate tuple (not "list") to tuple'

### DIFF
--- a/jnius_config.py
+++ b/jnius_config.py
@@ -41,7 +41,7 @@ def set_classpath(*path):
     if vm_running:
         raise ValueError("VM is already running, can't set classpath")
     global classpath
-    classpath = path
+    classpath = list(path)
 
 
 def add_classpath(*path):


### PR DESCRIPTION
Minor bugfix for code that calls `jnius_config.set_classpath(...); import jnius`.

Fixes:
```
File "/usr/local/lib/python2.7/dist-packages/jnius_config.py", line 72, in get_classpath
    return_classpath = classpath + return_classpath
TypeError: Error when calling the metaclass bases
    can only concatenate tuple (not "list") to tuple
```