### PR TITLE
fix: readme reflecting right fragment about java.lang.String

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,8 +27,9 @@ Hello world
 
 >>> Stack = autoclass('java.util.Stack')
 >>> stack = Stack()
->>> stack.push('hello')
->>> stack.push('world')
+>>> String = autoclass('java.lang.String')
+>>> stack.push(String('hello'))
+>>> stack.push(String('world'))
 >>> print stack.pop()
 world
 >>> print stack.pop()
@@ -119,7 +120,7 @@ class Hardware(JavaClass):
     accelerometerEnable = JavaStaticMethod('(Z)V')
     accelerometerReading = JavaStaticMethod('()[F')
     getDPI = JavaStaticMethod('()I')
-    
+
 # use that new class!
 print 'DPI is', Hardware.getDPI()
 


### PR DESCRIPTION
The example needs explicit instantiation of java.lang.String , at least with Java8. 

So - needs to be modified per se. 