### PR TITLE
resolve_class: use bytes default objects when required

### DIFF
--- a/jnius/jnius_export_class.pxi
+++ b/jnius/jnius_export_class.pxi
@@ -57,8 +57,8 @@ class MetaJavaClass(type):
 
         cdef JavaClassStorage jcs = JavaClassStorage()
         cdef bytes __javaclass__ = <bytes>classDict['__javaclass__']
-        cdef bytes __javainterfaces__ = <bytes>classDict.get('__javainterfaces__', '')
-        cdef bytes __javabaseclass__ = <bytes>classDict.get('__javabaseclass__', '')
+        cdef bytes __javainterfaces__ = <bytes>classDict.get('__javainterfaces__', b'')
+        cdef bytes __javabaseclass__ = <bytes>classDict.get('__javabaseclass__', b'')
         cdef jmethodID getProxyClass, getClassLoader
         cdef jclass *interfaces
         cdef jobject *jargs


### PR DESCRIPTION
Fixes a crash on Python 3.5.5 where `PyBytes_Check()` does not accept the
str() objects previously supplied as defaults for `__javainterfaces__` and so on. I'm not sure if this is a recent Python change or what.

Crash looks like:
```
jnius/jnius.c:17873: __pyx_pf_5jnius_5jnius_13MetaJavaClass_4resolve_class: assertion "PyBytes_Check(__pyx_v___javainterfaces__)" failed'
```

This is the cause of kivy/python-for-android#1247.