### PR TITLE
Fix class name generated by autoclass

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -167,7 +167,7 @@ Reflection functions
 
     >>> from jnius import autoclass
     >>> autoclass('java.lang.System')
-    <class 'jnius.java.lang.System'>
+    <class 'jnius.reflect.java.lang.System'>
 
     autoclass can also represent a nested Java class:
 


### PR DESCRIPTION
This is just a minor fix. It is important to show the determinism of generated class names.