### PR TITLE
Bump to 1.1.3

### DIFF
--- a/jnius/__init__.py
+++ b/jnius/__init__.py
@@ -7,7 +7,7 @@ Accessing Java classes from Python.
 All the documentation is available at: http://pyjnius.readthedocs.org
 '''
 
-__version__ = '1.1.2-dev'
+__version__ = '1.1.3'
 
 from .jnius import *  # noqa
 from .reflect import *  # noqa


### PR DESCRIPTION
Doing a release with the latest commit as `1.1.3` and p4a will use `1.1.2` as a tag prior to #356 to fix buildozer patch issues.