### PR TITLE
Convert Python array-like structures properly to Java Objects

### DIFF
--- a/examples/arraylists/arraylist.java
+++ b/examples/arraylists/arraylist.java
@@ -1,0 +1,48 @@
+// javac arraylist.java
+// java arraylist
+
+import java.lang.String;
+import java.util.List;
+import java.util.Arrays;
+import java.util.ArrayList;
+
+
+public class arraylist {
+    public static void main(String[] args) {
+        // Object based empty ArrayList
+        ArrayList<Object> jlist = new ArrayList<Object>();
+        System.out.println(jlist);
+        System.out.println(jlist.size());
+
+        // String array
+        String[] str_array = {"a", "b", "c"};
+        System.out.println(str_array.toString());
+        System.out.println(str_array.length);
+
+        // add the array of strings to the list
+        jlist.add(str_array);
+        System.out.println(jlist.toString());
+        System.out.println(jlist.size());
+
+        // create a new ArrayList from String array
+        ArrayList<Object> str_list = new ArrayList<Object>(
+            Arrays.asList(str_array.toString())
+        );
+        jlist.add(str_list);
+        System.out.println(jlist.toString());
+        System.out.println(jlist.size());
+
+        // add an empty Object to ArrayList
+        jlist.add(new Object());
+        System.out.println(jlist.toString());
+        System.out.println(jlist.size());
+
+        // new ArrayList to wrap everything up
+        ArrayList plain_list = new ArrayList();
+        plain_list.add(str_array);
+        plain_list.add(str_list);
+        plain_list.add(jlist);
+        System.out.println(plain_list.toString());
+        System.out.println(plain_list.size());
+    }
+}

--- a/examples/arraylists/arraylist.py
+++ b/examples/arraylists/arraylist.py
@@ -1,0 +1,54 @@
+# pylint: disable=invalid-name
+'''
+Example of nested ArrayList and passing empty tuple/list to Java functions.
+'''
+
+from __future__ import unicode_literals, print_function
+from jnius import autoclass, cast  # pylint: disable=import-error
+
+String = autoclass('java.lang.String')
+List = autoclass('java.util.List')
+Arrays = autoclass('java.util.Arrays')
+ArrayList = autoclass('java.util.ArrayList')
+JavaArray = autoclass('java.lang.reflect.Array')
+Object = autoclass('java.lang.Object')
+
+
+def sep_print(*args):
+    '''
+    Separate args because in <80char console (e.g. Windows)
+    is the output barely readable with [[, @, ;, ,, ...
+    '''
+    print(*args)
+    print('-' * 10)
+
+
+# Object based empty ArrayList
+jlist = ArrayList()
+sep_print(jlist, jlist.toString(), len(jlist))
+
+# String array
+str_array = JavaArray.newInstance(String, 3)
+for i, item in enumerate(('a', 'b', 'c')):
+    str_array[i] = String(item)
+sep_print(str_array, len(str_array))
+
+# add the array of strings to the list
+jlist.add(str_array)
+sep_print(jlist, jlist.toString(), len(jlist))
+
+# create a new ArrayList from String array
+str_list = ArrayList(Arrays.asList(str_array))
+jlist.add(str_list)
+sep_print(jlist, jlist.toString(), len(jlist))
+
+# add an empty Object to ArrayList
+jlist.add(Object())
+sep_print(jlist, jlist.toString(), len(jlist))
+
+# new ArrayList to wrap everything up
+plain_list = ArrayList()
+plain_list.add(str_array)
+plain_list.add(str_list)
+plain_list.add(jlist)
+sep_print(plain_list, plain_list.toString(), len(plain_list))

--- a/jnius/jnius_conversion.pxi
+++ b/jnius/jnius_conversion.pxi
@@ -485,6 +485,7 @@ cdef jstring convert_pystr_to_java(JNIEnv *j_env, basestring py_str) except NULL
 
 cdef jobject convert_pyarray_to_java(JNIEnv *j_env, definition, pyarray) except *:
     cdef jobject ret = NULL
+    cdef jobject nested = NULL
     cdef int array_size = len(pyarray)
     cdef int i
     cdef unsigned char c_tmp
@@ -621,6 +622,17 @@ cdef jobject convert_pyarray_to_java(JNIEnv *j_env, definition, pyarray) except 
                     j_env, <jobjectArray>ret, i, j_string
                 )
                 j_env[0].DeleteLocalRef(j_env, j_string)
+
+            # isinstance(arg, type) will return False
+            # ...and it's really weird
+            elif isinstance(arg, (tuple, list)):
+                nested = convert_pyarray_to_java(
+                    j_env, definition, arg
+                )
+                j_env[0].SetObjectArrayElement(
+                    j_env, <jobjectArray>ret, i, nested
+                )
+                j_env[0].DeleteLocalRef(j_env, nested)
 
             # no local refs to delete for class, type and object
             elif isinstance(arg, JavaClass):

--- a/jnius/jnius_conversion.pxi
+++ b/jnius/jnius_conversion.pxi
@@ -593,38 +593,61 @@ cdef jobject convert_pyarray_to_java(JNIEnv *j_env, definition, pyarray) except 
 
     elif definition[0] == 'L':
         defstr = str_for_c(definition[1:-1])
-        j_class = j_env[0].FindClass(
-                j_env, <bytes>defstr)
+        j_class = j_env[0].FindClass(j_env, <bytes>defstr)
+
         if j_class == NULL:
-            raise JavaException('Cannot create array with a class not '
-                    'found {0!r}'.format(definition[1:-1]))
+            raise JavaException(
+                'Cannot create array with a class not '
+                'found {0!r}'.format(definition[1:-1])
+            )
+
         ret = j_env[0].NewObjectArray(
-                j_env, array_size, j_class, NULL)
+            j_env, array_size, j_class, NULL
+        )
+
+        # iterate over each Python array element
+        # and add it to Object[].
         for i in range(array_size):
             arg = pyarray[i]
+
             if arg is None:
                 j_env[0].SetObjectArrayElement(
-                        j_env, <jobjectArray>ret, i, NULL)
+                    j_env, <jobjectArray>ret, i, NULL
+                )
+
             elif isinstance(arg, basestring):
                 j_string = convert_pystr_to_java(j_env, arg)
                 j_env[0].SetObjectArrayElement(
-                        j_env, <jobjectArray>ret, i, j_string)
+                    j_env, <jobjectArray>ret, i, j_string
+                )
                 j_env[0].DeleteLocalRef(j_env, j_string)
+
+            # no local refs to delete for class, type and object
             elif isinstance(arg, JavaClass):
                 jc = arg
                 check_assignable_from(j_env, jc, definition[1:-1])
                 j_env[0].SetObjectArrayElement(
-                        j_env, <jobjectArray>ret, i, jc.j_self.obj)
+                    j_env, <jobjectArray>ret, i, jc.j_self.obj
+                )
+
             elif isinstance(arg, type):
                 jc = arg
                 j_env[0].SetObjectArrayElement(
-                        j_env, <jobjectArray>ret, i, jc.j_cls)
+                    j_env, <jobjectArray>ret, i, jc.j_cls
+                )
+
             elif isinstance(arg, JavaObject):
                 jo = arg
                 j_env[0].SetObjectArrayElement(
-                        j_env, <jobjectArray>ret, i, jo.obj)
+                    j_env, <jobjectArray>ret, i, jo.obj
+                )
+
             else:
-                raise JavaException('Invalid variable used for L array', definition, pyarray)
+                raise JavaException(
+                    'Invalid variable {!r} used for L array {!r}'.format(
+                        pyarray, definition
+                    )
+                )
 
     elif definition[0] == '[':
         subdef = definition[1:]
@@ -640,6 +663,10 @@ cdef jobject convert_pyarray_to_java(JNIEnv *j_env, definition, pyarray) except 
             j_env[0].DeleteLocalRef(j_env, j_elem)
 
     else:
-        raise JavaException('Invalid array definition', definition, pyarray)
+        raise JavaException(
+            'Invalid array definition {!r} for variable {!r}'.format(
+                definition, pyarray
+            )
+        )
 
     return <jobject>ret

--- a/jnius/jnius_export_class.pxi
+++ b/jnius/jnius_export_class.pxi
@@ -993,6 +993,10 @@ cdef class JavaMultipleMethod(object):
             scores.append((score, signature))
 
         if not scores:
+            # @tito:
+            # if the java was waiting for an Object, and you didn't
+            # pass any of the PythonJavaClass, JavaClass, JavaObject,
+            # basestring, then it doesn't score it, and it won't work
             raise JavaException('No methods matching your arguments')
         scores.sort()
         score, signature = scores[-1]

--- a/jnius/jnius_utils.pxi
+++ b/jnius/jnius_utils.pxi
@@ -321,6 +321,9 @@ cdef int calculate_score(sign_args, args, is_varargs=False) except *:
                 elif isinstance(arg, basestring):
                     score += 5
                     continue
+                elif isinstance(arg, (list, tuple)):
+                    score += 5
+                    continue
                 return -1
 
             # accept an autoclass class for java/lang/Class.


### PR DESCRIPTION
Fixes resolving signatures with adding a score for `tuple` and `list`, passing `tuple` and `list` to Java functions and makes the logs more useful with properly printed signatures and passed values to functions.

Also minor explanation from @tito picked from our [Discord channel](https://chat.kivy.org).

I'm also starting with the `examples` folder for some basic examples. Hopefully more people will add something useful and I'll try to add interesting stuff while playing with Java.

Closes #349, #255 
Ref #35, #76