### PR TITLE
Fix conversion methods accepting java.lang.Object

### DIFF
--- a/jnius/jnius_compat.pxi
+++ b/jnius/jnius_compat.pxi
@@ -4,7 +4,7 @@ Handle Python 2 vs 3 differences here.
 
 from cpython.version cimport PY_MAJOR_VERSION
 
-cdef int PY3 = PY_MAJOR_VERSION >= 3
+cdef int PY2 = PY_MAJOR_VERSION < 3
 
 # because Cython's basestring doesn't work with isinstance() properly
 # and has differences between Python 2 and Python 3 runtime behavior

--- a/jnius/jnius_compat.pxi
+++ b/jnius/jnius_compat.pxi
@@ -4,6 +4,8 @@ Handle Python 2 vs 3 differences here.
 
 from cpython.version cimport PY_MAJOR_VERSION
 
+cdef int PY3 = PY_MAJOR_VERSION >= 3
+
 # because Cython's basestring doesn't work with isinstance() properly
 # and has differences between Python 2 and Python 3 runtime behavior
 # so it's not really usable unless some bug in the upstream is fixed

--- a/jnius/jnius_utils.pxi
+++ b/jnius/jnius_utils.pxi
@@ -1,7 +1,5 @@
-from cpython.version cimport PY_MAJOR_VERSION
-
 cdef str_for_c(s):
-     if PY_MAJOR_VERSION < 3:
+     if not PY3:
         if isinstance(s, unicode):
             return s.encode('utf-8')
         else:
@@ -10,7 +8,7 @@ cdef str_for_c(s):
         return s.encode('utf-8')
 
 cdef items_compat(d):
-     if PY_MAJOR_VERSION >= 3:
+     if PY3:
          return d.items()
      else:
         return d.iteritems()                
@@ -306,11 +304,11 @@ cdef int calculate_score(sign_args, args, is_varargs=False) except *:
                 continue
 
             # if it's a string, accept any python string
-            if r == 'java/lang/String' and isinstance(arg, base_string) and PY_MAJOR_VERSION < 3:
+            if r == 'java/lang/String' and isinstance(arg, base_string) and not PY3:
                 score += 10
                 continue
 
-            if r == 'java/lang/String' and isinstance(arg, str) and PY_MAJOR_VERSION >= 3:
+            if r == 'java/lang/String' and isinstance(arg, str) and PY3:
                 score += 10
                 continue
 
@@ -365,15 +363,15 @@ cdef int calculate_score(sign_args, args, is_varargs=False) except *:
                 score += 10
                 continue
 
-            if (r == '[B' or r == '[C') and isinstance(arg, base_string) and PY_MAJOR_VERSION < 3:
+            if (r == '[B' or r == '[C') and isinstance(arg, base_string) and not PY3:
                 score += 10
                 continue
 
-            if (r == '[B') and isinstance(arg, bytes) and PY_MAJOR_VERSION >= 3:
+            if (r == '[B') and isinstance(arg, bytes) and PY3:
                 score += 10
                 continue
 
-            if (r == '[C') and isinstance(arg, str) and PY_MAJOR_VERSION >= 3:
+            if (r == '[C') and isinstance(arg, str) and PY3:
                 score += 10
                 continue
 

--- a/jnius/jnius_utils.pxi
+++ b/jnius/jnius_utils.pxi
@@ -1,5 +1,5 @@
 cdef str_for_c(s):
-     if not PY3:
+     if PY2:
         if isinstance(s, unicode):
             return s.encode('utf-8')
         else:
@@ -8,7 +8,7 @@ cdef str_for_c(s):
         return s.encode('utf-8')
 
 cdef items_compat(d):
-     if PY3:
+     if not PY2:
          return d.items()
      else:
         return d.iteritems()                
@@ -304,11 +304,11 @@ cdef int calculate_score(sign_args, args, is_varargs=False) except *:
                 continue
 
             # if it's a string, accept any python string
-            if r == 'java/lang/String' and isinstance(arg, base_string) and not PY3:
+            if r == 'java/lang/String' and isinstance(arg, base_string) and PY2:
                 score += 10
                 continue
 
-            if r == 'java/lang/String' and isinstance(arg, str) and PY3:
+            if r == 'java/lang/String' and isinstance(arg, str) and not PY2:
                 score += 10
                 continue
 
@@ -369,15 +369,15 @@ cdef int calculate_score(sign_args, args, is_varargs=False) except *:
                 score += 10
                 continue
 
-            if (r == '[B' or r == '[C') and isinstance(arg, base_string) and not PY3:
+            if (r == '[B' or r == '[C') and isinstance(arg, base_string) and PY2:
                 score += 10
                 continue
 
-            if (r == '[B') and isinstance(arg, bytes) and PY3:
+            if (r == '[B') and isinstance(arg, bytes) and not PY2:
                 score += 10
                 continue
 
-            if (r == '[C') and isinstance(arg, str) and PY3:
+            if (r == '[C') and isinstance(arg, str) and not PY2:
                 score += 10
                 continue
 

--- a/jnius/jnius_utils.pxi
+++ b/jnius/jnius_utils.pxi
@@ -259,7 +259,7 @@ cdef int calculate_score(sign_args, args, is_varargs=False) except *:
             continue
 
         if r == 'C':
-            if not isinstance(arg, str) or args_len != 1:
+            if not isinstance(arg, str) or len(arg) != 1:
                 return -1
             score += 10
             continue
@@ -389,9 +389,9 @@ cdef int calculate_score(sign_args, args, is_varargs=False) except *:
                 return -1
 
             # calculate the score for our subarray
-            if args_len > 0:
+            if len(arg) > 0:
                 # if there are supplemantal arguments we compute the score
-                subscore = calculate_score([r[1:]] * args_len, arg)
+                subscore = calculate_score([r[1:]] * len(arg), arg)
                 if subscore == -1:
                     return -1
                 # the supplemental arguments match the varargs arguments

--- a/jnius/jnius_utils.pxi
+++ b/jnius/jnius_utils.pxi
@@ -224,15 +224,17 @@ cdef int calculate_score(sign_args, args, is_varargs=False) except *:
     cdef int index
     cdef int score = 0
     cdef JavaClass jc
+    cdef int args_len = len(args)
+    cdef int sign_args_len = len(sign_args)
 
-    if len(args) != len(sign_args) and not is_varargs:
+    if args_len != sign_args_len and not is_varargs:
         # if the number of arguments expected is not the same
         # as the number of arguments the method gets
         # it can not be the method we are looking for except
         # if the method has varargs aka. it takes
         # an undefined number of arguments
         return -1
-    elif len(args) == len(sign_args) and not is_varargs:
+    elif args_len == sign_args_len and not is_varargs:
         # if the method has the good number of arguments and
         # the method doesn't take varargs increment the score
         # so that it takes precedence over a method with the same
@@ -242,7 +244,7 @@ cdef int calculate_score(sign_args, args, is_varargs=False) except *:
         # (Integer, Integer, Integer) takes precedence over (Integer, Integer, Integer...)
         score += 10
 
-    for index in range(len(sign_args)):
+    for index in range(sign_args_len):
         r = sign_args[index]
         arg = args[index]
 
@@ -259,7 +261,7 @@ cdef int calculate_score(sign_args, args, is_varargs=False) except *:
             continue
 
         if r == 'C':
-            if not isinstance(arg, str) or len(arg) != 1:
+            if not isinstance(arg, str) or args_len != 1:
                 return -1
             score += 10
             continue
@@ -383,9 +385,9 @@ cdef int calculate_score(sign_args, args, is_varargs=False) except *:
                 return -1
 
             # calculate the score for our subarray
-            if len(arg) > 0:
+            if args_len > 0:
                 # if there are supplemantal arguments we compute the score
-                subscore = calculate_score([r[1:]] * len(arg), arg)
+                subscore = calculate_score([r[1:]] * args_len, arg)
                 if subscore == -1:
                     return -1
                 # the supplemental arguments match the varargs arguments

--- a/jnius/jnius_utils.pxi
+++ b/jnius/jnius_utils.pxi
@@ -324,6 +324,12 @@ cdef int calculate_score(sign_args, args, is_varargs=False) except *:
                 elif isinstance(arg, (list, tuple)):
                     score += 5
                     continue
+                elif isinstance(arg, int):
+                    score += 5
+                    continue
+                elif isinstance(arg, float):
+                    score += 5
+                    continue
                 return -1
 
             # accept an autoclass class for java/lang/Class.

--- a/setup.py
+++ b/setup.py
@@ -17,14 +17,14 @@ import sys
 from platform import machine
 from setup_sdist import SETUP_KWARGS
 
-PY3 = sys.version_info >= (3, 0, 0)
+PY2 = sys.version_info < (3, 0, 0)
 
 
 def getenv(key):
     '''Get value from environment and decode it.'''
     val = environ.get(key)
     if val is not None:
-        if PY3:
+        if not PY2:
             try:
                 return val.decode()
             except AttributeError:
@@ -107,7 +107,7 @@ elif PLATFORM == 'darwin':
         '/usr/libexec/java_home',
         stdout=subprocess.PIPE, shell=True).communicate()[0]
 
-    if PY3:
+    if not PY2:
         FRAMEWORK = FRAMEWORK.decode('utf-8')
 
     FRAMEWORK = FRAMEWORK.strip()
@@ -169,7 +169,7 @@ else:
                 'readlink -f `which javac` | sed "s:bin/javac::"',
                 shell=True, stdout=subprocess.PIPE).communicate()[0].strip()
 
-            if JDK_HOME is not None and PY3:
+            if JDK_HOME is not None and not PY2:
                 JDK_HOME = JDK_HOME.decode('utf-8')
 
     if not JDK_HOME or not exists(JDK_HOME):
@@ -243,7 +243,7 @@ else:
 # generate the config.pxi
 with open(join(dirname(__file__), 'jnius', 'config.pxi'), 'w') as fd:
     fd.write('DEF JNIUS_PLATFORM = {0!r}\n\n'.format(PLATFORM))
-    if PY3:
+    if not PY2:
         fd.write('DEF JNIUS_PYTHON3 = True\n\n')
     else:
         fd.write('DEF JNIUS_PYTHON3 = False\n\n')

--- a/tests/test_arraylist.py
+++ b/tests/test_arraylist.py
@@ -1,0 +1,22 @@
+from __future__ import absolute_import
+import unittest
+from jnius import autoclass
+
+
+class ArrayListTest(unittest.TestCase):
+
+    def test_output(self):
+        alist = autoclass('java.util.ArrayList')()
+        args = [0, 1, 5, -1, -5, 0.0, 1.0, 5.0, -1.0, -5.0, True, False]
+
+        for arg in args:
+            alist.add(arg)
+        for idx, arg in enumerate(args):
+            if isinstance(arg, bool):
+                self.assertEqual(str(alist[idx]), str(int(arg)))
+            else:
+                self.assertEqual(str(alist[idx]), str(arg))
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Closes #295.

```python
ls = ac('java.util.ArrayList')()
ls.add(0);ls.add(1);ls.add(5);ls.add(-1);ls.add(-5);ls.add(0.0);ls.add(1.0);
ls.add(5.0);ls.add(-1.0);ls.add(-5.0);ls.add(True);ls.add(False)
ac('java.lang.System').out.println(ls)
# [0, 1, 5, -1, -5, 0.0, 1.0, 5.0, -1.0, -5.0, 1, 0]
```