### PR TITLE
Always check for exception JavaClass.call_constructor()

### DIFF
--- a/jnius/jnius_export_class.pxi
+++ b/jnius/jnius_export_class.pxi
@@ -348,6 +348,10 @@ cdef class JavaClass(object):
             self.j_self = create_local_ref(j_env, j_self)
             j_env[0].DeleteLocalRef(j_env, j_self)
         finally:
+            # in case NewObjectA() throws an exception,
+            # the execution might not get further, but 'finally' block
+            # will still be called
+            check_exception(j_env)
             if j_args != NULL:
                 free(j_args)
 

--- a/tests/java-src/org/jnius/ConstructorTest.java
+++ b/tests/java-src/org/jnius/ConstructorTest.java
@@ -1,0 +1,23 @@
+package org.jnius;
+import java.lang.Character;
+
+
+public class ConstructorTest {
+    public int ret;
+
+    public ConstructorTest() {
+        ret = 753;
+    }
+
+    public ConstructorTest(int cret) {
+        ret = cret;
+    }
+
+    public ConstructorTest(char charet) {
+        ret = (int) charet;
+    }
+
+    public ConstructorTest(int cret, char charet) {
+        ret = cret + (int) charet;
+    }
+}

--- a/tests/test_constructor.py
+++ b/tests/test_constructor.py
@@ -1,0 +1,69 @@
+'''
+Test creating an instance of a Java class and fetching its values.
+'''
+
+from __future__ import absolute_import
+import unittest
+from jnius import autoclass, JavaException
+
+
+class TestConstructor(unittest.TestCase):
+    '''
+    TestCase for using constructors with PyJNIus.
+    '''
+
+    def test_constructor_none(self):
+        '''
+        Empty constructor, baked value in the .java file.
+        '''
+
+        ConstructorTest = autoclass('org.jnius.ConstructorTest')
+        inst = ConstructorTest()
+        self.assertEqual(inst.ret, 753)
+        self.assertTrue(ConstructorTest.getClass().isInstance(inst))
+
+    def test_constructor_int(self):
+        '''
+        Constructor expecting int and setting it as public 'ret' property.
+        '''
+
+        ConstructorTest = autoclass('org.jnius.ConstructorTest')
+        inst = ConstructorTest(123)
+        self.assertEqual(inst.ret, 123)
+        self.assertTrue(ConstructorTest.getClass().isInstance(inst))
+
+    def test_constructor_string(self):
+        '''
+        Constructor expecting char, casting it to int and setting it
+        as public 'ret' property.
+        '''
+
+        ConstructorTest = autoclass('org.jnius.ConstructorTest')
+        inst = ConstructorTest('a')
+        self.assertEqual(inst.ret, ord('a'))
+        self.assertTrue(ConstructorTest.getClass().isInstance(inst))
+
+    def test_constructor_int_string(self):
+        '''
+        Constructor expecting int and char, casting char to int and summing it
+        as public 'ret' property.
+        '''
+
+        ConstructorTest = autoclass('org.jnius.ConstructorTest')
+        inst = ConstructorTest(3, 'a')
+        self.assertEqual(inst.ret, 3 + ord('a'))
+        self.assertTrue(ConstructorTest.getClass().isInstance(inst))
+
+    def test_constructor_exception(self):
+        '''
+        No such constructor found (no such signature),
+        should raise JavaException.
+        '''
+
+        ConstructorTest = autoclass('org.jnius.ConstructorTest')
+        with self.assertRaises(JavaException):
+            ConstructorTest('1.', 2.0, False)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
In case NewObjectA() throws an exception, the execution might not get further, but 'finally' block will still be called. This might be caused by a Python exception raised either explicitly or by something just crashing randomly, so it's better to recover from that first than continue with broken JNI.

Closes #95.