### PR TITLE
Add warning about Java class comparing (.hashCode())

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -197,6 +197,11 @@ Reflection functions
         which you will find either as a result of `SomeClass.getClass()`
         or in the `__javaclass__` python attribute.
 
+    .. warning::
+        Currently `SomeClass.getClass()` returns a different Python object,
+        therefore to safely compare whether something is the same class in
+        Java use `A.hashCode() == B.hashCode()`.
+
 Java class implementation in Python
 -----------------------------------
 


### PR DESCRIPTION
Currently we do new Python object, therefore the only safe way to compare Java classes from Python is via `Class.hashCode()` results.