### PR TITLE
Get JDK/JRE path pythonically

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: generic
 
 os:
-  - osx
   - linux
+  - osx
 
 env:
   - PYTHON_VERSION="2.7" JAVA_VERSION="8"

--- a/setup.py
+++ b/setup.py
@@ -169,11 +169,8 @@ else:
             JDK_HOME = realpath(
                 subprocess.check_output(
                     ['which', 'javac']
-                ).strip()
+                ).decode('utf-8').strip()
             ).replace('bin/javac', '')
-
-            if JDK_HOME is not None and not PY2:
-                JDK_HOME = JDK_HOME.decode('utf-8')
 
     if not JDK_HOME or not exists(JDK_HOME):
         raise Exception('Unable to determine JDK_HOME')
@@ -186,7 +183,7 @@ else:
         JRE_HOME = realpath(
             subprocess.check_output(
                 ['which', 'java']
-            ).strip()
+            ).decode('utf-8').strip()
         ).replace('bin/java', '')
 
     # This dictionary converts values from platform.machine()

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,8 @@ try:
     import subprocess32 as subprocess
 except ImportError:
     import subprocess
-from os import environ, readlink
+import os
+from os import environ
 from os.path import dirname, join, exists
 import sys
 from platform import machine
@@ -165,9 +166,9 @@ else:
                 JDK_HOME = TMP_JDK_HOME
 
         else:
-            JDK_HOME = readlink(
+            JDK_HOME = os.readlink(
                 subprocess.Popen(
-                    ['which', 'javac'], stdout=subprocess.PIPE
+                    'which javac', stdout=subprocess.PIPE
                 ).communicate()[0].strip()
             ).replace('bin/javac', '')
 
@@ -182,9 +183,9 @@ else:
         JRE_HOME = join(JDK_HOME, 'jre')
 
     if PLATFORM != 'win32' and not JRE_HOME:
-        JRE_HOME = readlink(
+        JRE_HOME = os.readlink(
             subprocess.Popen(
-                ['which', 'java'], stdout=subprocess.PIPE
+                'which java', stdout=subprocess.PIPE
             ).communicate()[0].strip()
         ).replace('bin/java', '')
 

--- a/setup.py
+++ b/setup.py
@@ -167,11 +167,9 @@ else:
 
         else:
             JDK_HOME = os.readlink(
-                subprocess.Popen(
-                    ['which', 'javac'],
-                    stdout=subprocess.PIPE,
-                    env=os.environ.copy()
-                ).communicate()[0].strip()
+                subprocess.check_output(
+                    ['which', 'javac']
+                ).strip()
             ).replace('bin/javac', '')
 
             if JDK_HOME is not None and not PY2:
@@ -186,11 +184,9 @@ else:
 
     if PLATFORM != 'win32' and not JRE_HOME:
         JRE_HOME = os.readlink(
-            subprocess.Popen(
-                ['which', 'java'],
-                stdout=subprocess.PIPE,
-                env=os.environ.copy()
-            ).communicate()[0].strip()
+            subprocess.check_output(
+                ['which', 'java']
+            ).strip()
         ).replace('bin/java', '')
 
     # This dictionary converts values from platform.machine()

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ try:
     import subprocess32 as subprocess
 except ImportError:
     import subprocess
-from os import environ
+from os import environ, readlink
 from os.path import dirname, join, exists
 import sys
 from platform import machine
@@ -165,9 +165,11 @@ else:
                 JDK_HOME = TMP_JDK_HOME
 
         else:
-            JDK_HOME = subprocess.Popen(
-                'readlink -f `which javac` | sed "s:bin/javac::"',
-                shell=True, stdout=subprocess.PIPE).communicate()[0].strip()
+            JDK_HOME = readlink(
+                subprocess.Popen(
+                    ['which', 'javac'], stdout=subprocess.PIPE
+                ).communicate()[0].strip()
+            ).replace('bin/javac', '')
 
             if JDK_HOME is not None and not PY2:
                 JDK_HOME = JDK_HOME.decode('utf-8')
@@ -180,9 +182,11 @@ else:
         JRE_HOME = join(JDK_HOME, 'jre')
 
     if PLATFORM != 'win32' and not JRE_HOME:
-        JRE_HOME = subprocess.Popen(
-            'readlink -f `which java` | sed "s:bin/java::"',
-            shell=True, stdout=subprocess.PIPE).communicate()[0].strip()
+        JRE_HOME = readlink(
+            subprocess.Popen(
+                ['which', 'java'], stdout=subprocess.PIPE
+            ).communicate()[0].strip()
+        ).replace('bin/java', '')
 
     # This dictionary converts values from platform.machine()
     # to a "cpu" string. It is needed to set the correct lib path,

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ except ImportError:
     import subprocess
 import os
 from os import environ
-from os.path import dirname, join, exists
+from os.path import dirname, join, exists, realpath
 import sys
 from platform import machine
 from setup_sdist import SETUP_KWARGS
@@ -166,7 +166,7 @@ else:
                 JDK_HOME = TMP_JDK_HOME
 
         else:
-            JDK_HOME = os.readlink(
+            JDK_HOME = realpath(
                 subprocess.check_output(
                     ['which', 'javac']
                 ).strip()
@@ -183,7 +183,7 @@ else:
         JRE_HOME = join(JDK_HOME, 'jre')
 
     if PLATFORM != 'win32' and not JRE_HOME:
-        JRE_HOME = os.readlink(
+        JRE_HOME = realpath(
             subprocess.check_output(
                 ['which', 'java']
             ).strip()

--- a/setup.py
+++ b/setup.py
@@ -168,7 +168,9 @@ else:
         else:
             JDK_HOME = os.readlink(
                 subprocess.Popen(
-                    'which javac', stdout=subprocess.PIPE
+                    ['which', 'javac'],
+                    stdout=subprocess.PIPE,
+                    env=os.environ.copy()
                 ).communicate()[0].strip()
             ).replace('bin/javac', '')
 
@@ -185,7 +187,9 @@ else:
     if PLATFORM != 'win32' and not JRE_HOME:
         JRE_HOME = os.readlink(
             subprocess.Popen(
-                'which java', stdout=subprocess.PIPE
+                ['which', 'java'],
+                stdout=subprocess.PIPE,
+                env=os.environ.copy()
             ).communicate()[0].strip()
         ).replace('bin/java', '')
 


### PR DESCRIPTION
Remove `readlink -f` and `sed`, we have Python for replacing not `sed` + pipe and `os.readlink()` should work properly as a `readlink -f` alternative from Python's side.

Closes #100.