### PR TITLE
Convert java.lang.Long to INT if < 2 ** 31 else to LONG

### DIFF
--- a/jnius/jnius_conversion.pxi
+++ b/jnius/jnius_conversion.pxi
@@ -170,7 +170,11 @@ cdef convert_jobject_to_python(JNIEnv *j_env, definition, jobject j_object):
     if r == 'java/lang/Long':
         retclass = j_env[0].GetObjectClass(j_env, j_object)
         retmeth = j_env[0].GetMethodID(j_env, retclass, 'longValue', '()J')
-        return j_env[0].CallLongMethod(j_env, j_object, retmeth)
+        value = j_env[0].CallLongMethod(j_env, j_object, retmeth)
+        if value < 2 ** 31:
+            return j_env[0].CallIntMethod(j_env, j_object, retmeth)
+        else:
+            return j_env[0].CallLongMethod(j_env, j_object, retmeth)
     if r == 'java/lang/Integer':
         retclass = j_env[0].GetObjectClass(j_env, j_object)
         retmeth = j_env[0].GetMethodID(j_env, retclass, 'intValue', '()I')

--- a/jnius/jnius_conversion.pxi
+++ b/jnius/jnius_conversion.pxi
@@ -170,11 +170,7 @@ cdef convert_jobject_to_python(JNIEnv *j_env, definition, jobject j_object):
     if r == 'java/lang/Long':
         retclass = j_env[0].GetObjectClass(j_env, j_object)
         retmeth = j_env[0].GetMethodID(j_env, retclass, 'longValue', '()J')
-        value = j_env[0].CallLongMethod(j_env, j_object, retmeth)
-        if value < 2 ** 31:
-            return j_env[0].CallIntMethod(j_env, j_object, retmeth)
-        else:
-            return j_env[0].CallLongMethod(j_env, j_object, retmeth)
+        return j_env[0].CallLongMethod(j_env, j_object, retmeth)
     if r == 'java/lang/Integer':
         retclass = j_env[0].GetObjectClass(j_env, j_object)
         retmeth = j_env[0].GetMethodID(j_env, retclass, 'intValue', '()I')

--- a/jnius/jnius_proxy.pxi
+++ b/jnius/jnius_proxy.pxi
@@ -133,7 +133,9 @@ cdef jobject py_invoke0(JNIEnv *j_env, jobject j_this, jobject j_proxy, jobject
     if ret_signature == 'Ljava/lang/Object;':
         # generic object, try to manually convert it
         tp = type(ret)
-        if tp == int:
+        if PY2 and tp == int:
+            jtype = 'I'
+        elif (PY2 and tp == long) or tp == int:
             jtype = 'J'
         elif tp == float:
             jtype = 'D'

--- a/setup.py
+++ b/setup.py
@@ -156,6 +156,9 @@ else:
         if PLATFORM == 'win32':
             TMP_JDK_HOME = getenv('JAVA_HOME')
             print(TMP_JDK_HOME)
+            if not TMP_JDK_HOME:
+                raise Exception('Unable to find JAVA_HOME')
+
             # Remove /bin if it's appended to JAVA_HOME
             if TMP_JDK_HOME[-3:] == 'bin':
                 TMP_JDK_HOME = TMP_JDK_HOME[:-4]

--- a/tests/test_int_vs_long.py
+++ b/tests/test_int_vs_long.py
@@ -1,0 +1,58 @@
+from __future__ import absolute_import, unicode_literals
+import unittest
+from jnius import autoclass, cast, PythonJavaClass, java_method
+
+
+class TestImplemIterator(PythonJavaClass):
+    __javainterfaces__ = ['java/util/ListIterator']
+
+
+class TestImplem(PythonJavaClass):
+    __javainterfaces__ = ['java/util/List']
+
+    def __init__(self, *args):
+        super(TestImplem, self).__init__(*args)
+        self.data = list(args)
+
+    @java_method('()I')
+    def size(self):
+        return len(self.data)
+
+    @java_method('(I)Ljava/lang/Object;')
+    def get(self, index):
+        return self.data[index]
+
+    @java_method('(ILjava/lang/Object;)Ljava/lang/Object;')
+    def set(self, index, obj):
+        old_object = self.data[index]
+        self.data[index] = obj
+        return old_object
+
+
+class TestIntLongConversion(unittest.TestCase):
+    def test_reverse(self):
+        '''
+        String comparison because values are the same for INT and LONG,
+        but only __str__ shows the real difference.
+        '''
+
+        Collections = autoclass('java.util.Collections')
+        List = autoclass('java.util.List')
+        pylist = list(range(10))
+        a = TestImplem(*pylist)
+        self.assertEqual(a.data, pylist)
+        self.assertEqual(str(a.data), '[0, 1, 2, 3, 4, 5, 6, 7, 8, 9]')
+
+        # reverse the array, be sure it's converted back to INT!
+        Collections.reverse(a)
+
+        # conversion to/from Java objects hides INT/LONG conv on Py2
+        # which is wrong to switch between because even Java
+        # recognizes INT and LONG types separately (Py3 doesn't)
+        self.assertEqual(a.data, list(reversed(pylist)))
+        self.assertNotIn('L', str(a.data))
+        self.assertEqual(str(a.data), '[9, 8, 7, 6, 5, 4, 3, 2, 1, 0]')
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Convert java.lang.Long to INT if < 2 ** 31 else to LONG

LONG is in Py3 merged with INT type and renamed to INT without 'L' being present in the string representation of the number but having the full storage capacity of LONG. On Py2 however it will cause type issues when we convert java.lang.Long with size < 2 ** 31 into Py2 long and convert it back. Therefore convert java.lang.Long to Py2 long *only* if it exceeds the maximum value of INT (2 ** 31).