### PR TITLE
Avoid windows execution error when JAVA_HOME path has space (test on …

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -84,6 +84,8 @@ def find_javac(possible_homes):
     for home in possible_homes:
         for javac in [join(home, name), join(home, 'bin', name)]:
             if exists(javac):
+                if sys.platform == "win32": # Avoid path space execution error
+                    return'"%s"' % javac
                 return javac
     return name  # Fall back to "hope it's on the path"
 


### PR DESCRIPTION
On windows installation when JAVA_HOME path has a space on string python os module make path with '\\' symbol and space in path made trigger window execution error 

Example below

![image](https://user-images.githubusercontent.com/26009859/57740094-76138300-768c-11e9-81ad-822fee7b9ecf.png)

Then to support command execution on windows system, we need to put path between "" 

![image](https://user-images.githubusercontent.com/26009859/57740138-aeb35c80-768c-11e9-8c2d-69f86f28b8ee.png)
