### PR TITLE
add dunder __dir__ for java methods

### DIFF
--- a/jnius/jnius_export_class.pxi
+++ b/jnius/jnius_export_class.pxi
@@ -682,6 +682,9 @@ cdef class JavaMethod(object):
         self.j_cls = NULL
         self.j_self = None
 
+    def __dir__(self):
+        return list([readable_sig(self.definition, self.is_varargs)])
+
     def __init__(self, definition, **kwargs):
         super(JavaMethod, self).__init__()
         self.definition = definition
@@ -957,6 +960,9 @@ cdef class JavaMultipleMethod(object):
     cdef dict instance_methods
     cdef bytes name
     cdef bytes classname
+
+    def __dir__(self):
+        return [readable_sig(args, is_varargs) for args, static, is_varargs in self.definitions]
 
     def __cinit__(self, definition, **kwargs):
         self.j_self = None

--- a/jnius/jnius_utils.pxi
+++ b/jnius/jnius_utils.pxi
@@ -405,7 +405,7 @@ cdef int calculate_score(sign_args, args, is_varargs=False) except *:
 
 cdef readable_sig(sig, is_var):
     """
-    Converts JNI signature to easily readable Signature.
+    Converts JNI signature to easily readable signature.
     :param sig: JNI signature string
     :param is_var: if the function has varargs
     :return:([arg], rtn)

--- a/tests/test_dir.py
+++ b/tests/test_dir.py
@@ -1,0 +1,43 @@
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
+import unittest
+from jnius.reflect import autoclass
+
+class DirTest(unittest.TestCase):
+
+    def test_varargs_dir(self):
+        cls = autoclass("java.lang.System")
+        assert isinstance(dir(cls.out.printf), list)
+        #[(['java/lang/String', 'java/lang/Object...'], 'java/io/PrintStream'),
+        # (['java/util/Locale', 'java/lang/String', 'java/lang/Object...'], 'java/io/PrintStream')]
+        for f in dir(cls.out.printf):
+            assert isinstance(f, tuple)
+
+    def test_array_dir(self):
+        cls = autoclass("java.util.List")
+        assert isinstance(dir(cls.toArray), list)
+        #[([], 'java/lang/Object[]'),
+        # (['java/lang/Object[]'], 'java/lang/Object[]')]
+        for f in dir(cls.toArray):
+            assert isinstance(f, tuple)
+
+    def test_dir(self):
+        cls = autoclass("java.lang.String")
+        assert isinstance(dir(cls.valueOf), list)
+        # [(['boolean'], 'java/lang/String'),
+        #  (['char'], 'java/lang/String'),
+        #  (['char[]'], 'java/lang/String'),
+        #  (['char[]', 'int', 'int'], 'java/lang/String'),
+        #  (['double'], 'java/lang/String'),
+        #  (['float'], 'java/lang/String'),
+        #  (['int'], 'java/lang/String'),
+        #  (['java/lang/Object'], 'java/lang/String'),
+        #  (['long'], 'java/lang/String')]
+        for f in dir(cls.charAt):
+            assert isinstance(f, tuple)
+
+
+
+
+

--- a/tests/test_dir.py
+++ b/tests/test_dir.py
@@ -7,24 +7,32 @@ from jnius.reflect import autoclass
 class DirTest(unittest.TestCase):
 
     def test_varargs_dir(self):
+        # >>> from jnius import autoclass
+        # >>> cls = autoclass('java.lang.System')
+        # >>> dir(cls.out.printf)
+        # [(['java/lang/String', 'java/lang/Object...'], 'java/io/PrintStream'),
+        # (['java/util/Locale', 'java/lang/String', 'java/lang/Object...'], 'java/io/PrintStream')]
         cls = autoclass("java.lang.System")
         assert isinstance(dir(cls.out.printf), list)
-        #[(['java/lang/String', 'java/lang/Object...'], 'java/io/PrintStream'),
-        # (['java/util/Locale', 'java/lang/String', 'java/lang/Object...'], 'java/io/PrintStream')]
         for f in dir(cls.out.printf):
             assert isinstance(f, tuple)
 
     def test_array_dir(self):
+        # >>> from jnius import autoclass
+        # >>> cls = autoclass('java.util.List')
+        # >>> dir(cls.toArray)
+        # [([], 'java/lang/Object[]'),
+        # (['java/lang/Object[]'], 'java/lang/Object[]')]
         cls = autoclass("java.util.List")
         assert isinstance(dir(cls.toArray), list)
-        #[([], 'java/lang/Object[]'),
-        # (['java/lang/Object[]'], 'java/lang/Object[]')]
+
         for f in dir(cls.toArray):
             assert isinstance(f, tuple)
 
     def test_dir(self):
-        cls = autoclass("java.lang.String")
-        assert isinstance(dir(cls.valueOf), list)
+        # >>> from jnius import autoclass
+        # >>> cls = autoclass('java.lang.String')
+        # >>> dir(cls.valueOf)
         # [(['boolean'], 'java/lang/String'),
         #  (['char'], 'java/lang/String'),
         #  (['char[]'], 'java/lang/String'),
@@ -34,6 +42,8 @@ class DirTest(unittest.TestCase):
         #  (['int'], 'java/lang/String'),
         #  (['java/lang/Object'], 'java/lang/String'),
         #  (['long'], 'java/lang/String')]
+        cls = autoclass("java.lang.String")
+        assert isinstance(dir(cls.valueOf), list)
         for f in dir(cls.charAt):
             assert isinstance(f, tuple)
 


### PR DESCRIPTION
For readable / usable propose, added `__dir__` to JavaMethod & JavaMultipleMethod. 
It is more human readable than JNI signatures.

Solves #419 issue
`readable_sig` is in .pxi but if it can be moved to .py anytime. I can make some test cases also.
