### PR TITLE
Link to libjli, not libjvm, on macOS

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -125,7 +125,7 @@ elif PLATFORM == 'darwin':
             )
         )]
     else:
-        LIB_LOCATION = 'jre/lib/server/libjvm.dylib'
+        LIB_LOCATION = 'jre/lib/jli/libjli.dylib'
 
         # We want to favor Java installation declaring JAVA_HOME
         if getenv('JAVA_HOME'):
@@ -136,7 +136,7 @@ elif PLATFORM == 'darwin':
         if not exists(FULL_LIB_LOCATION):
             # In that case, the Java version is very likely >=9.
             # So we need to modify the `libjvm.so` path.
-            LIB_LOCATION = 'lib/server/libjvm.dylib'
+            LIB_LOCATION = 'lib/jli/libjli.dylib'
 
         INCLUDE_DIRS = [
             '{0}/include'.format(FRAMEWORK),

--- a/setup.py
+++ b/setup.py
@@ -137,6 +137,12 @@ elif PLATFORM == 'darwin':
             # In that case, the Java version is very likely >=9.
             # So we need to modify the `libjvm.so` path.
             LIB_LOCATION = 'lib/jli/libjli.dylib'
+            FULL_LIB_LOCATION = join(FRAMEWORK, LIB_LOCATION)
+
+        if not exists(FULL_LIB_LOCATION):
+            # adoptopenjdk12 doesn't have the jli subfolder either
+            LIB_LOCATION = 'lib/libjli.dylib'
+            FULL_LIB_LOCATION = join(FRAMEWORK, LIB_LOCATION)
 
         INCLUDE_DIRS = [
             '{0}/include'.format(FRAMEWORK),


### PR DESCRIPTION
When linking to Java on a macOS system without Apple Java 6 installed, an error is given when attempting to load Java via JNI:

> No Java runtime present, requesting install.

And a dialog box appears saying:

> You need to install the legacy Java SE 6 runtime.

Unfortunately, this is no longer possible on current versions of macOS.

Linking to `libjli` sidesteps the issue, avoiding Apple's overzealous linkage check, while still allowing access to Java's native API.

Fixes #277 for real. Also closes #406.

See also:
* xamarin/java.interop#198
* imagej/pyimagej#10