### PR TITLE
Keep quiet when deducing jdk_home from JAVA_HOME

### DIFF
--- a/jnius/env.py
+++ b/jnius/env.py
@@ -117,7 +117,6 @@ def get_jdk_home(platform):
     if not jdk_home:
         if platform == 'win32':
             TMP_JDK_HOME = getenv('JAVA_HOME')
-            print(TMP_JDK_HOME)
             if not TMP_JDK_HOME:
                 raise Exception('Unable to find JAVA_HOME')
 


### PR DESCRIPTION
It's standard practice of Java to set the environment variable `JAVA_HOME` to the JDK installation directory. Thus it's no surprise to find a `bin/javac` under it. Better print nothing (esp. directly to stdout) when the detection is successful.

By the way, I don't think `JDK_HOME` is a good environment variable name for `$JAVA_HOME/bin`. None of the conventional names like `R_HOME` , `GOROOT`, `GOPATH` etc. points to a `bin` directory.