### PR TITLE
Python workaround for wrong constructor selection cf #474

### DIFF
--- a/jnius/jnius_export_class.pxi
+++ b/jnius/jnius_export_class.pxi
@@ -297,12 +297,10 @@ cdef class JavaClass(object):
                 )
         else:
             scores = []
-            requestedDefn = kwargs.get('param_types', None)
+            requestedDefn = kwargs.get('signature', None)
             for definition, is_varargs in definitions:
                 found_definitions.append(definition)
                 d_ret, d_args = parse_definition(definition)
-                #print(definition)
-                #print(d_args)
                 if requestedDefn == definition:
                     assert not is_varargs
                     score=1

--- a/jnius/jnius_export_class.pxi
+++ b/jnius/jnius_export_class.pxi
@@ -297,7 +297,7 @@ cdef class JavaClass(object):
                 )
         else:
             scores = []
-            requestedDefn = kwargs.get('signature', None)
+            requestedDefn = kwargs.pop('signature', None)
             for definition, is_varargs in definitions:
                 found_definitions.append(definition)
                 d_ret, d_args = parse_definition(definition)

--- a/jnius/jnius_export_class.pxi
+++ b/jnius/jnius_export_class.pxi
@@ -253,7 +253,7 @@ cdef class JavaClass(object):
         self.j_cls = jcs.j_cls
 
         if 'noinstance' not in kwargs:
-            self.call_constructor(args)
+            self.call_constructor(args, kwargs)
             self.resolve_methods()
             self.resolve_fields()
 
@@ -262,7 +262,7 @@ cdef class JavaClass(object):
         self.resolve_methods()
         self.resolve_fields()
 
-    cdef void call_constructor(self, args) except *:
+    cdef void call_constructor(self, args, kwargs) except *:
         # the goal is to find the class constructor, and call it with the
         # correct arguments.
         cdef jvalue *j_args = NULL
@@ -297,9 +297,18 @@ cdef class JavaClass(object):
                 )
         else:
             scores = []
+            requestedDefn = kwargs.get('param_types', None)
             for definition, is_varargs in definitions:
                 found_definitions.append(definition)
                 d_ret, d_args = parse_definition(definition)
+                #print(definition)
+                #print(d_args)
+                if requestedDefn == definition:
+                    assert not is_varargs
+                    score=1
+                    scores.append((score, definition, d_ret, d_args, args))
+                    break
+                
                 if is_varargs:
                     args_ = args[:len(d_args) - 1] + (args[len(d_args) - 1:],)
                 else:

--- a/tests/java-src/org/jnius/ConstructorTest.java
+++ b/tests/java-src/org/jnius/ConstructorTest.java
@@ -20,4 +20,12 @@ public class ConstructorTest {
     public ConstructorTest(int cret, char charet) {
         ret = cret + (int) charet;
     }
+
+    public ConstructorTest(Object DO_NOT_CALL) {
+        throw new Error();
+    }
+
+    public ConstructorTest(java.io.OutputStream os) {
+        ret = 42;
+    }
 }

--- a/tests/test_constructor.py
+++ b/tests/test_constructor.py
@@ -51,7 +51,7 @@ class TestConstructor(unittest.TestCase):
 
         outputStream = autoclass('java.lang.System').out
         ConstructorTest = autoclass('org.jnius.ConstructorTest')
-        inst = ConstructorTest(outputStream, param_types="(Ljava/io/OutputStream;)V")
+        inst = ConstructorTest(outputStream, signature="(Ljava/io/OutputStream;)V")
         self.assertEqual(inst.ret, 42)
         self.assertTrue(ConstructorTest.getClass().isInstance(inst))
 

--- a/tests/test_constructor.py
+++ b/tests/test_constructor.py
@@ -43,6 +43,18 @@ class TestConstructor(unittest.TestCase):
         self.assertEqual(inst.ret, ord('a'))
         self.assertTrue(ConstructorTest.getClass().isInstance(inst))
 
+
+    def test_constructor_multiobj(self):
+        '''
+        Constructor expecting String.
+        '''
+
+        outputStream = autoclass('java.lang.System').out
+        ConstructorTest = autoclass('org.jnius.ConstructorTest')
+        inst = ConstructorTest(outputStream, param_types="(Ljava/io/OutputStream;)V")
+        self.assertEqual(inst.ret, 42)
+        self.assertTrue(ConstructorTest.getClass().isInstance(inst))
+
     def test_constructor_int_string(self):
         '''
         Constructor expecting int and char, casting char to int and summing it


### PR DESCRIPTION
Please see this as a possible workaround for #474. Constructors can take optional kwargs that provide the specification for the desired constructor. Unit tests included.