### PR TITLE
add support for java.lang.AutoCloseable #494

### DIFF
--- a/jnius/reflect.py
+++ b/jnius/reflect.py
@@ -341,9 +341,11 @@ def _getitem(self, index):
 
 # protocol_map is a user-accessible API for patching class instances with additional methods 
 protocol_map = {
-    'java.util.List' : {
-        '__getitem__' : _getitem,
+    'java.util.Collection' : {
         '__len__' : lambda self: self.size()
+    },
+    'java.util.List' : {
+        '__getitem__' : _getitem        
     },
     # this also addresses java.io.Closeable
     'java.lang.AutoCloseable' : {

--- a/jnius/reflect.py
+++ b/jnius/reflect.py
@@ -312,17 +312,13 @@ def _getitem(self, index):
         else:
             raise
 
-
+# interface_map is a user-accessible API for patching class instances with additional methods 
 interface_map = {
     'java.util.List' : {
         '__getitem__' : _getitem,
         '__len__' : lambda self: self.size()
     },
-    #we need both java.io.Closeable and java.lang.AutoCloseable. 
-    'java.io.Closeable' : {
-        '__enter__' : lambda self: self,
-        '__exit__' : lambda self, type, value, traceback: self.close()
-    },
+    #this also addresses java.io.Closeable
     'java.lang.AutoCloseable' : {
         '__enter__' : lambda self: self,
         '__exit__' : lambda self, type, value, traceback: self.close()

--- a/jnius/reflect.py
+++ b/jnius/reflect.py
@@ -1,7 +1,7 @@
 from __future__ import absolute_import
 from __future__ import unicode_literals
 from __future__ import division
-__all__ = ('autoclass', 'ensureclass')
+__all__ = ('autoclass', 'ensureclass', 'interface_map')
 from six import with_metaclass
 import logging
 
@@ -48,7 +48,7 @@ class Class(with_metaclass(MetaJavaClass, JavaClass)):
     getSigners = JavaMethod('()[Ljava/lang/Object;')
     getSuperclass = JavaMethod('()Ljava/lang/Class;')
     isArray = JavaMethod('()Z')
-    isAssignableFrom = JavaMethod('(Ljava/lang/reflect/Class;)Z')
+    isAssignableFrom = JavaMethod('(Ljava/lang/Class;)Z')
     isInstance = JavaMethod('(Ljava/lang/Object;)Z')
     isInterface = JavaMethod('()Z')
     isPrimitive = JavaMethod('()Z')
@@ -269,24 +269,16 @@ def autoclass(clsname):
         else:
             cls = _cls
 
-    def _getitem(self, index):
-        try:
-            return self.get(index)
-        except JavaException as e:
-            # initialize the subclass before getting the Class.forName
-            # otherwise isInstance does not know of the subclass
-            mock_exception_object = autoclass(e.classname)()
-            if find_javaclass("java.lang.IndexOutOfBoundsException").isInstance(mock_exception_object):
-                # python for...in iteration checks for end of list by waiting for IndexError
-                raise IndexError()
-            else:
-                raise
-
-    for iclass in c.getInterfaces():
-        if iclass.getName() == 'java.util.List':
-            classDict['__getitem__'] = _getitem
-            classDict['__len__'] = lambda self: self.size()
-            break
+    for interfacename in interface_map.keys():
+        intf = find_javaclass(interfacename)
+        if intf is None:
+            raise Exception('Java interface {0} in interface_map not found'.format(intf))
+        #this equivalent to instanceof()
+        #we use this as c.getInterfaces() doesnt 
+        #contain interfaces implemented by superclasses
+        if intf.isAssignableFrom(c):
+            for pname, plambda in interface_map[interfacename].items():
+                classDict[pname] = plambda
 
     for field in c.getFields():
         static = Modifier.isStatic(field.getModifiers())
@@ -304,3 +296,35 @@ def autoclass(clsname):
         clsname,  # .replace('.', '_'),
         (JavaClass, ),
         classDict)
+
+
+## dunder method for List
+def _getitem(self, index):
+    try:
+        return self.get(index)
+    except JavaException as e:
+        # initialize the subclass before getting the Class.forName
+        # otherwise isInstance does not know of the subclass
+        mock_exception_object = autoclass(e.classname)()
+        if find_javaclass("java.lang.IndexOutOfBoundsException").isInstance(mock_exception_object):
+            # python for...in iteration checks for end of list by waiting for IndexError
+            raise IndexError()
+        else:
+            raise
+
+
+interface_map = {
+    'java.util.List' : {
+        '__getitem__' : _getitem,
+        '__len__' : lambda self: self.size()
+    },
+    #we need both java.io.Closeable and java.lang.AutoCloseable. 
+    'java.io.Closeable' : {
+        '__enter__' : lambda self: self,
+        '__exit__' : lambda self, type, value, traceback: self.close()
+    },
+    'java.lang.AutoCloseable' : {
+        '__enter__' : lambda self: self,
+        '__exit__' : lambda self, type, value, traceback: self.close()
+    }
+}

--- a/tests/java-src/org/jnius/CloseableClass.java
+++ b/tests/java-src/org/jnius/CloseableClass.java
@@ -1,0 +1,15 @@
+package org.jnius;
+
+import java.io.Closeable;
+
+public class CloseableClass implements Closeable{
+    public static boolean open = true;
+
+    public CloseableClass() {
+        open = true;
+    }
+
+    public void close() {
+        open = false;
+    }
+}

--- a/tests/test_arraylist.py
+++ b/tests/test_arraylist.py
@@ -16,6 +16,7 @@ class ArrayListTest(unittest.TestCase):
                 self.assertEqual(str(alist[idx]), str(int(arg)))
             else:
                 self.assertEqual(str(alist[idx]), str(arg))
+        self.assertEqual(len(args), len(alist))
 
 
 if __name__ == '__main__':

--- a/tests/test_closeable.py
+++ b/tests/test_closeable.py
@@ -12,7 +12,7 @@ class TestConstructor(unittest.TestCase):
     TestCase for using java.io.Closeable dunder
     '''
 
-    #this checkes that closeable are converted to the correct dunder methods
+    #this checkes that java.lang.AutoCloseable instances gain the correct dunder methods
     def test_stringreader_closeable(self):
         swCheck = autoclass("java.io.StringWriter")()
         self.assertTrue("__enter__" in dir(swCheck))
@@ -22,6 +22,8 @@ class TestConstructor(unittest.TestCase):
             sw.write("Hello")
             
     #this checkes that closeable dunder methods are actually called
+    #org.jnius.CloseableClass has java.io.Closeable, to differ from
+    #java.lang.AutoCloseable (which is what is in interface_map)
     def test_our_closeable(self):
         ourcloseableClz = autoclass("org.jnius.CloseableClass")
         self.assertTrue("__enter__" in dir(ourcloseableClz()))

--- a/tests/test_closeable.py
+++ b/tests/test_closeable.py
@@ -4,7 +4,7 @@ Test creating for java.io.Closeable dunder
 
 from __future__ import absolute_import
 import unittest
-from jnius import autoclass, JavaException, interface_map
+from jnius import autoclass, JavaException, protocol_map
 
 
 class TestConstructor(unittest.TestCase):
@@ -12,7 +12,7 @@ class TestConstructor(unittest.TestCase):
     TestCase for using java.io.Closeable dunder
     '''
 
-    #this checkes that java.lang.AutoCloseable instances gain the correct dunder methods
+    # this checkes that java.lang.AutoCloseable instances gain the correct dunder methods
     def test_stringreader_closeable(self):
         swCheck = autoclass("java.io.StringWriter")()
         self.assertTrue("__enter__" in dir(swCheck))
@@ -21,9 +21,9 @@ class TestConstructor(unittest.TestCase):
         with autoclass("java.io.StringWriter")() as sw:
             sw.write("Hello")
             
-    #this checkes that closeable dunder methods are actually called
-    #org.jnius.CloseableClass has java.io.Closeable, to differ from
-    #java.lang.AutoCloseable (which is what is in interface_map)
+    # this checkes that closeable dunder methods are actually called
+    # org.jnius.CloseableClass has java.io.Closeable, to differ from
+    # java.lang.AutoCloseable (which is what is in interface_map)
     def test_our_closeable(self):
         ourcloseableClz = autoclass("org.jnius.CloseableClass")
         self.assertTrue("__enter__" in dir(ourcloseableClz()))
@@ -35,4 +35,4 @@ class TestConstructor(unittest.TestCase):
         self.assertFalse(ourcloseableClz.open)
 
     def test_interface_map(self):
-       self.assertTrue("java.util.List" in interface_map)
+       self.assertTrue("java.util.List" in protocol_map)

--- a/tests/test_closeable.py
+++ b/tests/test_closeable.py
@@ -1,0 +1,36 @@
+'''
+Test creating for java.io.Closeable dunder
+'''
+
+from __future__ import absolute_import
+import unittest
+from jnius import autoclass, JavaException, interface_map
+
+
+class TestConstructor(unittest.TestCase):
+    '''
+    TestCase for using java.io.Closeable dunder
+    '''
+
+    #this checkes that closeable are converted to the correct dunder methods
+    def test_stringreader_closeable(self):
+        swCheck = autoclass("java.io.StringWriter")()
+        self.assertTrue("__enter__" in dir(swCheck))
+        self.assertTrue("__exit__" in dir(swCheck))
+
+        with autoclass("java.io.StringWriter")() as sw:
+            sw.write("Hello")
+            
+    #this checkes that closeable dunder methods are actually called
+    def test_our_closeable(self):
+        ourcloseableClz = autoclass("org.jnius.CloseableClass")
+        self.assertTrue("__enter__" in dir(ourcloseableClz()))
+        self.assertTrue("__exit__" in dir(ourcloseableClz()))
+
+        self.assertTrue(ourcloseableClz.open)
+        with ourcloseableClz() as ourcloseable2:
+            self.assertTrue(ourcloseableClz.open)
+        self.assertFalse(ourcloseableClz.open)
+
+    def test_interface_map(self):
+       self.assertTrue("java.util.List" in interface_map)

--- a/tests/test_closeable.py
+++ b/tests/test_closeable.py
@@ -7,13 +7,16 @@ import unittest
 from jnius import autoclass, JavaException, protocol_map
 
 
-class TestConstructor(unittest.TestCase):
+class TestCloseable(unittest.TestCase):
     '''
     TestCase for using java.io.Closeable dunder
     '''
 
-    # this checkes that java.lang.AutoCloseable instances gain the correct dunder methods
     def test_stringreader_closeable(self):
+        '''
+        this checkes that java.lang.AutoCloseable instances gain
+        the correct dunder methods
+        '''
         swCheck = autoclass("java.io.StringWriter")()
         self.assertTrue("__enter__" in dir(swCheck))
         self.assertTrue("__exit__" in dir(swCheck))
@@ -21,10 +24,12 @@ class TestConstructor(unittest.TestCase):
         with autoclass("java.io.StringWriter")() as sw:
             sw.write("Hello")
             
-    # this checkes that closeable dunder methods are actually called
-    # org.jnius.CloseableClass has java.io.Closeable, to differ from
-    # java.lang.AutoCloseable (which is what is in interface_map)
     def test_our_closeable(self):
+        '''
+        this checkes that closeable dunder methods are actually called
+        org.jnius.CloseableClass has java.io.Closeable, to differ from
+        java.lang.AutoCloseable (which is what is in interface_map)
+        '''
         ourcloseableClz = autoclass("org.jnius.CloseableClass")
         self.assertTrue("__enter__" in dir(ourcloseableClz()))
         self.assertTrue("__exit__" in dir(ourcloseableClz()))

--- a/tests/test_closeable.py
+++ b/tests/test_closeable.py
@@ -34,5 +34,5 @@ class TestConstructor(unittest.TestCase):
             self.assertTrue(ourcloseableClz.open)
         self.assertFalse(ourcloseableClz.open)
 
-    def test_interface_map(self):
+    def test_protocol_map(self):
        self.assertTrue("java.util.List" in protocol_map)

--- a/tests/test_reflect.py
+++ b/tests/test_reflect.py
@@ -47,6 +47,16 @@ class ReflectTest(unittest.TestCase):
         self.assertEqual(stack.pop(), 'world')
         self.assertEqual(stack.pop(), 'hello')
     
+    def test_collection(self):
+        HashSet = autoclass('java.util.HashSet')
+        aset = HashSet()
+        aset.add('hello')
+        aset.add('world')
+        #check that the __len__ dunder is applied to a Collection not a List
+        self.assertEqual(2, len(aset))
+        #check that the __len__ dunder is applied to it cast as a Collection
+        self.assertEqual(2, len(cast("java.util.Collection", aset)))
+
     def test_list_interface(self):
         ArrayList = autoclass('java.util.ArrayList')
         words = ArrayList()
@@ -62,6 +72,7 @@ class ReflectTest(unittest.TestCase):
         words.add('world')
         q = cast('java.util.Queue', words)
         self.assertEqual(2, q.size())
+        self.assertEqual(2, len(q))
         self.assertIsNotNone(q.iterator())
 
     def test_super_object(self):


### PR DESCRIPTION
Here is a patch for #494
Some possible areas for feedback: 
 - is calling find_javaclass() for every interface in interface_map everytime autoclass() is called expensive?
 - isAssignableFrom() doesnt just check interfaces, we can also check all classes. So perhaps interface_map isnt the best name. 
 - Should there be a method for accessing interface_map instead of exporting it directly?
 - what happens if interface_map contains the class that is being called, e.g. 
```
from jnius import autoclass, interface_map
interface_map["x.y"] = { "__size__" : lambda self : self.size() }
autoclass("x.y")
```