### PR TITLE
add include_protected and include_private options to autoclass

### DIFF
--- a/jnius/jnius_export_class.pxi
+++ b/jnius/jnius_export_class.pxi
@@ -109,11 +109,14 @@ class MetaJavaBase(type):
 cdef dict jclass_register = {}
 
 
+# NOTE: The classparams default value in MetaJavaClass.__new__ and
+# MetaJavaClass.get_javaclass need to be consistent with the include_protected
+# and include_private default values in reflect.autoclass.
 class MetaJavaClass(MetaJavaBase):
-    def __new__(meta, classname, bases, classDict):
+    def __new__(meta, classname, bases, classDict, classparams=(False, False)):
         meta.resolve_class(classDict)
         tp = type.__new__(meta, str(classname), bases, classDict)
-        jclass_register[classDict['__javaclass__']] = tp
+        jclass_register[(classDict['__javaclass__'], classparams)] = tp
         return tp
 
     def __subclasscheck__(cls, value):
@@ -145,8 +148,8 @@ class MetaJavaClass(MetaJavaBase):
         return super(MetaJavaClass, cls).__subclasscheck__(value)
 
     @staticmethod
-    def get_javaclass(name):
-        return jclass_register.get(name)
+    def get_javaclass(name, classparams=(False, False)):
+        return jclass_register.get((name, classparams))
 
     @classmethod
     def resolve_class(meta, classDict):

--- a/jnius/jnius_export_class.pxi
+++ b/jnius/jnius_export_class.pxi
@@ -113,7 +113,7 @@ cdef dict jclass_register = {}
 # MetaJavaClass.get_javaclass need to be consistent with the include_protected
 # and include_private default values in reflect.autoclass.
 class MetaJavaClass(MetaJavaBase):
-    def __new__(meta, classname, bases, classDict, classparams=(False, False)):
+    def __new__(meta, classname, bases, classDict, classparams=(True, True)):
         meta.resolve_class(classDict)
         tp = type.__new__(meta, str(classname), bases, classDict)
         jclass_register[(classDict['__javaclass__'], classparams)] = tp

--- a/jnius/reflect.py
+++ b/jnius/reflect.py
@@ -196,7 +196,7 @@ def log_method(method, name, signature):
     )
 
 
-def autoclass(clsname):
+def autoclass(clsname, public_only=False):
     jniname = clsname.replace('.', '/')
     cls = MetaJavaClass.get_javaclass(jniname)
     if cls:
@@ -222,9 +222,9 @@ def autoclass(clsname):
     while cls is not None:
         level += 1
         if cls is c:
-          methods = cls.getDeclaredMethods()
+            methods = cls.getDeclaredMethods()
         else:
-          methods = cls.getMethods()
+            methods = cls.getMethods()
         methods_name = [x.getName() for x in methods]
 
         for index, method in enumerate(methods):
@@ -235,6 +235,8 @@ def autoclass(clsname):
             # only one method available
             if methods_name.count(name) == 1:
                 static = Modifier.isStatic(method.getModifiers())
+                if public_only and not Modifier.isPublic(method.getModifiers()):
+                    continue
                 varargs = method.isVarArgs()
                 sig = '({0}){1}'.format(
                     ''.join([get_signature(x) for x in method.getParameterTypes()]),
@@ -253,6 +255,8 @@ def autoclass(clsname):
                 if subname != name:
                     continue
                 method = methods[index]
+                if public_only and not Modifier.isPublic(method.getModifiers()):
+                    continue
                 sig = '({0}){1}'.format(
                     ''.join([get_signature(x) for x in method.getParameterTypes()]),
                     get_signature(method.getReturnType()))
@@ -290,6 +294,8 @@ def autoclass(clsname):
 
     for field in c.getFields():
         static = Modifier.isStatic(field.getModifiers())
+        if public_only and not Modifier.isPublic(field.getModifiers()):
+            continue
         sig = get_signature(field.getType())
         cls = JavaStaticField if static else JavaField
         classDict[field.getName()] = cls(sig)

--- a/jnius/reflect.py
+++ b/jnius/reflect.py
@@ -294,7 +294,7 @@ def autoclass(clsname, public_only=False):
             classDict['__len__'] = lambda self: self.size()
             break
 
-    for field in c.getFields():
+    for field in c.getDeclaredFields():
         field_modifiers = field.getModifiers()
         static = Modifier.isStatic(field_modifiers)
         if public_only and not Modifier.isPublic(field_modifiers):

--- a/jnius/reflect.py
+++ b/jnius/reflect.py
@@ -234,8 +234,9 @@ def autoclass(clsname, public_only=False):
 
             # only one method available
             if methods_name.count(name) == 1:
-                static = Modifier.isStatic(method.getModifiers())
-                if public_only and not Modifier.isPublic(method.getModifiers()):
+                method_modifiers = method.getModifiers()
+                static = Modifier.isStatic(method_modifiers)
+                if public_only and not Modifier.isPublic(method_modifiers):
                     continue
                 varargs = method.isVarArgs()
                 sig = '({0}){1}'.format(
@@ -255,7 +256,8 @@ def autoclass(clsname, public_only=False):
                 if subname != name:
                     continue
                 method = methods[index]
-                if public_only and not Modifier.isPublic(method.getModifiers()):
+                method_modifiers = method.getModifiers()
+                if public_only and not Modifier.isPublic(method_modifiers):
                     continue
                 sig = '({0}){1}'.format(
                     ''.join([get_signature(x) for x in method.getParameterTypes()]),
@@ -263,7 +265,7 @@ def autoclass(clsname, public_only=False):
 
                 if log.level <= logging.DEBUG:
                     log_method(method, name, sig)
-                signatures.append((sig, Modifier.isStatic(method.getModifiers()), method.isVarArgs()))
+                signatures.append((sig, Modifier.isStatic(method_modifiers), method.isVarArgs()))
 
             classDict[name] = JavaMultipleMethod(signatures)
 
@@ -293,8 +295,9 @@ def autoclass(clsname, public_only=False):
             break
 
     for field in c.getFields():
-        static = Modifier.isStatic(field.getModifiers())
-        if public_only and not Modifier.isPublic(field.getModifiers()):
+        field_modifiers = field.getModifiers()
+        static = Modifier.isStatic(field_modifiers)
+        if public_only and not Modifier.isPublic(field_modifiers):
             continue
         sig = get_signature(field.getType())
         cls = JavaStaticField if static else JavaField

--- a/jnius/reflect.py
+++ b/jnius/reflect.py
@@ -211,7 +211,7 @@ def identify_hierarchy(cls, level, concrete=True):
     yield cls, level
 
 
-def autoclass(clsname, include_protected=True, include_private=True):
+def autoclass(clsname, include_protected=False, include_private=False):
     jniname = clsname.replace('.', '/')
     cls = MetaJavaClass.get_javaclass(jniname)
     if cls:
@@ -292,7 +292,7 @@ def autoclass(clsname, include_protected=True, include_private=True):
             # multiple signatures
             signatures = []
             log.debug("method %s has %d multiple signatures in hierarchy of cls %s" % (name, len(cls_methods[name]), c))
-            
+
             paramsig_to_level=defaultdict(lambda: float('inf'))
             # we now identify if any have the same signature, as we will call the _lowest_ in the hierarchy,
             # as reflected in min level
@@ -325,13 +325,6 @@ def autoclass(clsname, include_protected=True, include_private=True):
         if cls_name in protocol_map:
             for pname, plambda in protocol_map[cls_name].items():
                 classDict[pname] = plambda  
-
-    # for field in c.getFields():
-    #     print(f'adding field {field.getName()}')
-    #     static = Modifier.isStatic(field.getModifiers())
-    #     sig = get_signature(field.getType())
-    #     cls = JavaStaticField if static else JavaField
-    #     classDict[field.getName()] = cls(sig)
 
     for field_name, (field, _) in cls_fields.items():
         field_modifier = field.getModifiers()

--- a/jnius/reflect.py
+++ b/jnius/reflect.py
@@ -211,9 +211,12 @@ def identify_hierarchy(cls, level, concrete=True):
     yield cls, level
 
 
+# NOTE: if you change the include_protected or include_private default values,
+# you also must change the classparams default value in MetaJavaClass.__new__
+# and MetaJavaClass.get_javaclass.
 def autoclass(clsname, include_protected=False, include_private=False):
     jniname = clsname.replace('.', '/')
-    cls = MetaJavaClass.get_javaclass(jniname)
+    cls = MetaJavaClass.get_javaclass(jniname, classparams=(include_protected, include_private))
     if cls:
         return cls
 
@@ -342,7 +345,8 @@ def autoclass(clsname, include_protected=False, include_private=False):
         MetaJavaClass,
         clsname,
         (JavaClass, ),
-        classDict)
+        classDict,
+        classparams=(include_protected, include_private))
 
 
 ## dunder method for List

--- a/jnius/reflect.py
+++ b/jnius/reflect.py
@@ -278,7 +278,7 @@ def autoclass(clsname, include_protected=True, include_private=True):
                 cls_fields[field_name] = (field, level)
 
     # the fields are analyzed before methods so that if a method and a field
-    # have the same name, the field will take precidence in classDict.
+    # have the same name, the field will take precedence in classDict.
     for field_name, (field, _) in cls_fields.items():
         field_modifier = field.getModifiers()
         static = Modifier.isStatic(field_modifier)

--- a/tests/java-src/org/jnius/ChildVisibilityTest.java
+++ b/tests/java-src/org/jnius/ChildVisibilityTest.java
@@ -1,0 +1,65 @@
+package org.jnius;
+
+import java.lang.String;
+
+public class ChildVisibilityTest extends VisibilityTest {
+    public String fieldChildPublic = "ChildPublic";
+    protected String fieldChildProtected = "ChildProtected";
+    private String fieldChildPrivate = "ChildPrivate";
+
+    static public String fieldChildStaticPublic = "ChildStaticPublic";
+    static protected String fieldChildStaticProtected = "ChildStaticProtected";
+    static private String fieldChildStaticPrivate = "ChildStaticPrivate";
+
+    public String methodChildPublic() {
+        return fieldChildPublic;
+    }
+
+    protected String methodChildProtected() {
+        return fieldChildProtected;
+    }
+
+    private String methodChildPrivate() {
+        return fieldChildPrivate;
+    }
+
+    protected boolean methodMultiArgs(boolean a, boolean b) {
+        return a & !b;
+    }
+
+    private boolean methodMultiArgs(boolean a, boolean b, boolean c) {
+        return a & !b & c;
+    }
+
+    // dummy method to avoid warning about unused methods
+    public String methodChildDummy() {
+        this.methodMultiArgs(true, true, false);
+        return this.methodChildPrivate();
+    }
+
+    static public String methodChildStaticPublic() {
+        return fieldChildStaticPublic;
+    }
+
+    static protected String methodChildStaticProtected() {
+        return fieldChildStaticProtected;
+    }
+
+    static private String methodChildStaticPrivate() {
+        return fieldChildStaticPrivate;
+    }
+
+    static protected boolean methodStaticMultiArgs(boolean a, boolean b) {
+        return a & !b;
+    }
+
+    static private boolean methodStaticMultiArgs(boolean a, boolean b, boolean c) {
+        return a & !b & c;
+    }
+
+    // dummy method to avoid warning about unused methods
+    static public String methodChildStaticDummy() {
+        ChildVisibilityTest.methodStaticMultiArgs(true, true, true);
+        return ChildVisibilityTest.methodChildStaticPrivate();
+    }
+}

--- a/tests/java-src/org/jnius/VisibilityTest.java
+++ b/tests/java-src/org/jnius/VisibilityTest.java
@@ -23,6 +23,10 @@ public class VisibilityTest {
         return fieldPrivate;
     }
 
+    public String methodDummy() {
+        return this.methodPrivate();
+    }
+
     static public String methodStaticPublic() {
         return fieldStaticPublic;
     }
@@ -33,5 +37,9 @@ public class VisibilityTest {
 
     static private String methodStaticPrivate() {
         return fieldStaticPrivate;
+    }
+
+    static public String methodStaticDummy() {
+        return VisibilityTest.methodStaticPrivate();
     }
 }

--- a/tests/java-src/org/jnius/VisibilityTest.java
+++ b/tests/java-src/org/jnius/VisibilityTest.java
@@ -23,6 +23,7 @@ public class VisibilityTest {
         return fieldPrivate;
     }
 
+    // dummy method to avoid warning methodPrivate() isn't used
     public String methodDummy() {
         return this.methodPrivate();
     }
@@ -39,6 +40,7 @@ public class VisibilityTest {
         return fieldStaticPrivate;
     }
 
+    // dummy method to avoid warning methodStaticPrivate() isn't used
     static public String methodStaticDummy() {
         return VisibilityTest.methodStaticPrivate();
     }

--- a/tests/java-src/org/jnius/VisibilityTest.java
+++ b/tests/java-src/org/jnius/VisibilityTest.java
@@ -1,0 +1,37 @@
+package org.jnius;
+
+import java.lang.String;
+
+public class VisibilityTest {
+    public String fieldPublic = "fieldPublic";
+    protected String fieldProtected = "fieldProtected";
+    private String fieldPrivate = "fieldPrivate";
+
+    static public String fieldStaticPublic = "fieldStaticPublic";
+    static protected String fieldStaticProtected = "fieldStaticProtected";
+    static private String fieldStaticPrivate = "fieldStaticPrivate";
+
+    public String methodPublic() {
+        return "methodPublic";
+    }
+
+    protected String methodProtected() {
+        return "methodProtected";
+    }
+
+    private String methodPrivate() {
+        return "methodPrivate";
+    }
+
+    static public String methodStaticPublic() {
+        return "methodStaticPublic";
+    }
+
+    static protected String methodStaticProtected() {
+        return "methodStaticProtected";
+    }
+
+    static private String methodStaticPrivate() {
+        return "methodStaticPrivate";
+    }
+}

--- a/tests/java-src/org/jnius/VisibilityTest.java
+++ b/tests/java-src/org/jnius/VisibilityTest.java
@@ -23,6 +23,10 @@ public class VisibilityTest {
         return fieldPrivate;
     }
 
+    public boolean methodMultiArgs(boolean a) {
+        return a;
+    }
+
     // dummy method to avoid warning methodPrivate() isn't used
     public String methodDummy() {
         return this.methodPrivate();
@@ -38,6 +42,10 @@ public class VisibilityTest {
 
     static private String methodStaticPrivate() {
         return fieldStaticPrivate;
+    }
+
+    static public boolean methodStaticMultiArgs(boolean a) {
+        return a;
     }
 
     // dummy method to avoid warning methodStaticPrivate() isn't used

--- a/tests/java-src/org/jnius/VisibilityTest.java
+++ b/tests/java-src/org/jnius/VisibilityTest.java
@@ -3,35 +3,35 @@ package org.jnius;
 import java.lang.String;
 
 public class VisibilityTest {
-    public String fieldPublic = "fieldPublic";
-    protected String fieldProtected = "fieldProtected";
-    private String fieldPrivate = "fieldPrivate";
+    public String fieldPublic = "Public";
+    protected String fieldProtected = "Protected";
+    private String fieldPrivate = "Private";
 
-    static public String fieldStaticPublic = "fieldStaticPublic";
-    static protected String fieldStaticProtected = "fieldStaticProtected";
-    static private String fieldStaticPrivate = "fieldStaticPrivate";
+    static public String fieldStaticPublic = "StaticPublic";
+    static protected String fieldStaticProtected = "StaticProtected";
+    static private String fieldStaticPrivate = "StaticPrivate";
 
     public String methodPublic() {
-        return "methodPublic";
+        return fieldPublic;
     }
 
     protected String methodProtected() {
-        return "methodProtected";
+        return fieldProtected;
     }
 
     private String methodPrivate() {
-        return "methodPrivate";
+        return fieldPrivate;
     }
 
     static public String methodStaticPublic() {
-        return "methodStaticPublic";
+        return fieldStaticPublic;
     }
 
     static protected String methodStaticProtected() {
-        return "methodStaticProtected";
+        return fieldStaticProtected;
     }
 
     static private String methodStaticPrivate() {
-        return "methodStaticPrivate";
+        return fieldStaticPrivate;
     }
 }

--- a/tests/test_visibility_all.py
+++ b/tests/test_visibility_all.py
@@ -1,0 +1,43 @@
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
+import sys
+import unittest
+from jnius.reflect import autoclass
+
+try:
+    long
+except NameError:
+    # Python 3
+    long = int
+
+
+def py2_encode(uni):
+    if sys.version_info < (3, 0):
+        uni = uni.encode('utf-8')
+    return uni
+
+
+class VisibilityAllTest(unittest.TestCase):
+
+    def test_static_fields_all(self):
+        Test = autoclass('org.jnius.PublicOnlyTest')
+
+        self.assertTrue(hasattr(Test, 'fieldStaticPublic'))
+        self.assertTrue(hasattr(Test, 'fieldStaticProtected'))
+        self.assertTrue(hasattr(Test, 'fieldStaticPrivate'))
+
+        self.assertEqual(Test.fieldStaticPublic, py2_encode("fieldStaticPublic"))
+        self.assertEqual(Test.fieldStaticProtected, py2_encode("fieldStaticProtected"))
+        self.assertEqual(Test.fieldStaticPrivate, py2_encode("fieldStaticPrivate"))
+
+    def test_static_methods_all(self):
+        Test = autoclass('org.jnius.PublicOnlyTest')
+
+        self.assertTrue(hasattr(Test, 'methodStaticPublic'))
+        self.assertTrue(hasattr(Test, 'methodStaticProtected'))
+        self.assertTrue(hasattr(Test, 'methodStaticPrivate'))
+
+        self.assertEqual(Test.methodStaticPublic(), py2_encode("methodStaticPublic"))
+        self.assertEqual(Test.methodStaticProtected(), py2_encode("methodStaticProtected"))
+        self.assertEqual(Test.methodStaticPrivate(), py2_encode("methodStaticPrivate"))

--- a/tests/test_visibility_all.py
+++ b/tests/test_visibility_all.py
@@ -41,3 +41,27 @@ class VisibilityAllTest(unittest.TestCase):
         self.assertEqual(Test.methodStaticPublic(), py2_encode("StaticPublic"))
         self.assertEqual(Test.methodStaticProtected(), py2_encode("StaticProtected"))
         self.assertEqual(Test.methodStaticPrivate(), py2_encode("StaticPrivate"))
+
+    def test_fields_all(self):
+        Test = autoclass('org.jnius.VisibilityTest')
+        test = Test()
+
+        self.assertTrue(hasattr(test, 'fieldPublic'))
+        # self.assertTrue(hasattr(test, 'fieldProtected'))
+        # self.assertTrue(hasattr(test, 'fieldPrivate'))
+
+        self.assertEqual(test.fieldPublic, py2_encode("Public"))
+        # self.assertEqual(test.fieldProtected, py2_encode("Protected"))
+        # self.assertEqual(test.fieldPrivate, py2_encode("Private"))
+
+    def test_methods_all(self):
+        Test = autoclass('org.jnius.VisibilityTest')
+        test = Test()
+
+        self.assertTrue(hasattr(test, 'methodPublic'))
+        self.assertTrue(hasattr(test, 'methodProtected'))
+        self.assertTrue(hasattr(test, 'methodPrivate'))
+
+        self.assertEqual(test.methodPublic(), py2_encode("Public"))
+        self.assertEqual(test.methodProtected(), py2_encode("Protected"))
+        self.assertEqual(test.methodPrivate(), py2_encode("Private"))

--- a/tests/test_visibility_all.py
+++ b/tests/test_visibility_all.py
@@ -24,12 +24,12 @@ class VisibilityAllTest(unittest.TestCase):
         Test = autoclass('org.jnius.VisibilityTest')
 
         self.assertTrue(hasattr(Test, 'fieldStaticPublic'))
-        # self.assertTrue(hasattr(Test, 'fieldStaticProtected'))
-        # self.assertTrue(hasattr(Test, 'fieldStaticPrivate'))
+        self.assertTrue(hasattr(Test, 'fieldStaticProtected'))
+        self.assertTrue(hasattr(Test, 'fieldStaticPrivate'))
 
         self.assertEqual(Test.fieldStaticPublic, py2_encode("StaticPublic"))
-        # self.assertEqual(Test.fieldStaticProtected, py2_encode("StaticProtected"))
-        # self.assertEqual(Test.fieldStaticPrivate, py2_encode("StaticPrivate"))
+        self.assertEqual(Test.fieldStaticProtected, py2_encode("StaticProtected"))
+        self.assertEqual(Test.fieldStaticPrivate, py2_encode("StaticPrivate"))
 
     def test_static_methods_all(self):
         Test = autoclass('org.jnius.VisibilityTest')
@@ -47,12 +47,12 @@ class VisibilityAllTest(unittest.TestCase):
         test = Test()
 
         self.assertTrue(hasattr(test, 'fieldPublic'))
-        # self.assertTrue(hasattr(test, 'fieldProtected'))
-        # self.assertTrue(hasattr(test, 'fieldPrivate'))
+        self.assertTrue(hasattr(test, 'fieldProtected'))
+        self.assertTrue(hasattr(test, 'fieldPrivate'))
 
         self.assertEqual(test.fieldPublic, py2_encode("Public"))
-        # self.assertEqual(test.fieldProtected, py2_encode("Protected"))
-        # self.assertEqual(test.fieldPrivate, py2_encode("Private"))
+        self.assertEqual(test.fieldProtected, py2_encode("Protected"))
+        self.assertEqual(test.fieldPrivate, py2_encode("Private"))
 
     def test_methods_all(self):
         Test = autoclass('org.jnius.VisibilityTest')

--- a/tests/test_visibility_all.py
+++ b/tests/test_visibility_all.py
@@ -21,23 +21,23 @@ def py2_encode(uni):
 class VisibilityAllTest(unittest.TestCase):
 
     def test_static_fields_all(self):
-        Test = autoclass('org.jnius.PublicOnlyTest')
+        Test = autoclass('org.jnius.VisibilityTest')
 
         self.assertTrue(hasattr(Test, 'fieldStaticPublic'))
-        self.assertTrue(hasattr(Test, 'fieldStaticProtected'))
-        self.assertTrue(hasattr(Test, 'fieldStaticPrivate'))
+        # self.assertTrue(hasattr(Test, 'fieldStaticProtected'))
+        # self.assertTrue(hasattr(Test, 'fieldStaticPrivate'))
 
-        self.assertEqual(Test.fieldStaticPublic, py2_encode("fieldStaticPublic"))
-        self.assertEqual(Test.fieldStaticProtected, py2_encode("fieldStaticProtected"))
-        self.assertEqual(Test.fieldStaticPrivate, py2_encode("fieldStaticPrivate"))
+        self.assertEqual(Test.fieldStaticPublic, py2_encode("StaticPublic"))
+        # self.assertEqual(Test.fieldStaticProtected, py2_encode("StaticProtected"))
+        # self.assertEqual(Test.fieldStaticPrivate, py2_encode("StaticPrivate"))
 
     def test_static_methods_all(self):
-        Test = autoclass('org.jnius.PublicOnlyTest')
+        Test = autoclass('org.jnius.VisibilityTest')
 
         self.assertTrue(hasattr(Test, 'methodStaticPublic'))
         self.assertTrue(hasattr(Test, 'methodStaticProtected'))
         self.assertTrue(hasattr(Test, 'methodStaticPrivate'))
 
-        self.assertEqual(Test.methodStaticPublic(), py2_encode("methodStaticPublic"))
-        self.assertEqual(Test.methodStaticProtected(), py2_encode("methodStaticProtected"))
-        self.assertEqual(Test.methodStaticPrivate(), py2_encode("methodStaticPrivate"))
+        self.assertEqual(Test.methodStaticPublic(), py2_encode("StaticPublic"))
+        self.assertEqual(Test.methodStaticProtected(), py2_encode("StaticProtected"))
+        self.assertEqual(Test.methodStaticPrivate(), py2_encode("StaticPrivate"))

--- a/tests/test_visibility_all.py
+++ b/tests/test_visibility_all.py
@@ -159,3 +159,25 @@ class VisibilityAllTest(unittest.TestCase):
         self.assertTrue(test.methodMultiArgs(True))
         self.assertTrue(test.methodMultiArgs(True, False))
         self.assertTrue(test.methodMultiArgs(True, False, True))
+
+    def test_check_method_vs_field(self):
+        """check that HashMap and ArrayList have a size method and not a size field.
+
+        Both the HashMap and ArrayList implementations have a `size()` method
+        that is a wrapper for an `int` field also named `size`. The `autoclass`
+        function must pick one of these two. If it were to pick the field, this
+        would cause an "'int' object is not callable" TypeError when attempting
+        to call the size method. This unit test is here to ensure that future
+        changes to `autoclass` continue to prefer methods over fields.    
+        """
+
+        def assert_is_method(obj, name):
+            multiple = "JavaMultipleMethod" in str(type(obj.__class__.__dict__[name]))
+            single = "JavaMethod" in str(type(obj.__class__.__dict__[name]))
+            self.assertTrue(multiple or single)
+
+        hm = autoclass("java.util.HashMap", include_protected=True, include_private=True)()
+        assert_is_method(hm, 'size')
+
+        al = autoclass("java.util.ArrayList", include_protected=True, include_private=True)()
+        assert_is_method(al, 'size')

--- a/tests/test_visibility_all.py
+++ b/tests/test_visibility_all.py
@@ -3,7 +3,9 @@ from __future__ import division
 from __future__ import absolute_import
 import sys
 import unittest
+import jnius_config
 from jnius.reflect import autoclass
+
 
 try:
     long
@@ -21,7 +23,8 @@ def py2_encode(uni):
 class VisibilityAllTest(unittest.TestCase):
 
     def test_static_fields_all(self):
-        Test = autoclass('org.jnius.VisibilityTest')
+
+        Test = autoclass('org.jnius.VisibilityTest', include_protected=True, include_private=True)
 
         self.assertTrue(hasattr(Test, 'fieldStaticPublic'))
         self.assertTrue(hasattr(Test, 'fieldStaticProtected'))
@@ -32,7 +35,8 @@ class VisibilityAllTest(unittest.TestCase):
         self.assertEqual(Test.fieldStaticPrivate, py2_encode("StaticPrivate"))
 
     def test_static_methods_all(self):
-        Test = autoclass('org.jnius.VisibilityTest')
+
+        Test = autoclass('org.jnius.VisibilityTest', include_protected=True, include_private=True)
 
         self.assertTrue(hasattr(Test, 'methodStaticPublic'))
         self.assertTrue(hasattr(Test, 'methodStaticProtected'))
@@ -43,7 +47,8 @@ class VisibilityAllTest(unittest.TestCase):
         self.assertEqual(Test.methodStaticPrivate(), py2_encode("StaticPrivate"))
 
     def test_fields_all(self):
-        Test = autoclass('org.jnius.VisibilityTest')
+
+        Test = autoclass('org.jnius.VisibilityTest', include_protected=True, include_private=True)
         test = Test()
 
         self.assertTrue(hasattr(test, 'fieldPublic'))
@@ -55,7 +60,8 @@ class VisibilityAllTest(unittest.TestCase):
         self.assertEqual(test.fieldPrivate, py2_encode("Private"))
 
     def test_methods_all(self):
-        Test = autoclass('org.jnius.VisibilityTest')
+
+        Test = autoclass('org.jnius.VisibilityTest', include_protected=True, include_private=True)
         test = Test()
 
         self.assertTrue(hasattr(test, 'methodPublic'))

--- a/tests/test_visibility_all.py
+++ b/tests/test_visibility_all.py
@@ -4,6 +4,7 @@ from __future__ import absolute_import
 import sys
 import unittest
 import jnius_config
+from jnius import JavaMultipleMethod
 from jnius.reflect import autoclass
 
 
@@ -23,7 +24,6 @@ def py2_encode(uni):
 class VisibilityAllTest(unittest.TestCase):
 
     def test_static_fields_all(self):
-
         Test = autoclass('org.jnius.VisibilityTest', include_protected=True, include_private=True)
 
         self.assertTrue(hasattr(Test, 'fieldStaticPublic'))
@@ -34,8 +34,26 @@ class VisibilityAllTest(unittest.TestCase):
         self.assertEqual(Test.fieldStaticProtected, py2_encode("StaticProtected"))
         self.assertEqual(Test.fieldStaticPrivate, py2_encode("StaticPrivate"))
 
-    def test_static_methods_all(self):
+    def test_child_static_fields_all(self):
+        Test = autoclass('org.jnius.ChildVisibilityTest', include_protected=True, include_private=True)
 
+        self.assertTrue(hasattr(Test, 'fieldStaticPublic'))
+        self.assertTrue(hasattr(Test, 'fieldStaticProtected'))
+        self.assertTrue(hasattr(Test, 'fieldStaticPrivate'))
+
+        self.assertEqual(Test.fieldStaticPublic, py2_encode("StaticPublic"))
+        self.assertEqual(Test.fieldStaticProtected, py2_encode("StaticProtected"))
+        self.assertEqual(Test.fieldStaticPrivate, py2_encode("StaticPrivate"))
+
+        self.assertTrue(hasattr(Test, 'fieldChildStaticPublic'))
+        self.assertTrue(hasattr(Test, 'fieldChildStaticProtected'))
+        self.assertTrue(hasattr(Test, 'fieldChildStaticPrivate'))
+
+        self.assertEqual(Test.fieldChildStaticPublic, py2_encode("ChildStaticPublic"))
+        self.assertEqual(Test.fieldChildStaticProtected, py2_encode("ChildStaticProtected"))
+        self.assertEqual(Test.fieldChildStaticPrivate, py2_encode("ChildStaticPrivate"))
+
+    def test_static_methods_all(self):
         Test = autoclass('org.jnius.VisibilityTest', include_protected=True, include_private=True)
 
         self.assertTrue(hasattr(Test, 'methodStaticPublic'))
@@ -46,8 +64,26 @@ class VisibilityAllTest(unittest.TestCase):
         self.assertEqual(Test.methodStaticProtected(), py2_encode("StaticProtected"))
         self.assertEqual(Test.methodStaticPrivate(), py2_encode("StaticPrivate"))
 
-    def test_fields_all(self):
+    def test_child_static_methods_all(self):
+        Test = autoclass('org.jnius.ChildVisibilityTest', include_protected=True, include_private=True)
 
+        self.assertTrue(hasattr(Test, 'methodStaticPublic'))
+        self.assertTrue(hasattr(Test, 'methodStaticProtected'))
+        self.assertTrue(hasattr(Test, 'methodStaticPrivate'))
+
+        self.assertEqual(Test.methodStaticPublic(), py2_encode("StaticPublic"))
+        self.assertEqual(Test.methodStaticProtected(), py2_encode("StaticProtected"))
+        self.assertEqual(Test.methodStaticPrivate(), py2_encode("StaticPrivate"))
+
+        self.assertTrue(hasattr(Test, 'methodChildStaticPublic'))
+        self.assertTrue(hasattr(Test, 'methodChildStaticProtected'))
+        self.assertTrue(hasattr(Test, 'methodChildStaticPrivate'))
+
+        self.assertEqual(Test.methodChildStaticPublic(), py2_encode("ChildStaticPublic"))
+        self.assertEqual(Test.methodChildStaticProtected(), py2_encode("ChildStaticProtected"))
+        self.assertEqual(Test.methodChildStaticPrivate(), py2_encode("ChildStaticPrivate"))
+
+    def test_fields_all(self):
         Test = autoclass('org.jnius.VisibilityTest', include_protected=True, include_private=True)
         test = Test()
 
@@ -59,8 +95,27 @@ class VisibilityAllTest(unittest.TestCase):
         self.assertEqual(test.fieldProtected, py2_encode("Protected"))
         self.assertEqual(test.fieldPrivate, py2_encode("Private"))
 
-    def test_methods_all(self):
+    def test_child_fields_all(self):
+        Test = autoclass('org.jnius.ChildVisibilityTest', include_protected=True, include_private=True)
+        test = Test()
 
+        self.assertTrue(hasattr(test, 'fieldPublic'))
+        self.assertTrue(hasattr(test, 'fieldProtected'))
+        self.assertTrue(hasattr(test, 'fieldPrivate'))
+
+        self.assertEqual(test.fieldPublic, py2_encode("Public"))
+        self.assertEqual(test.fieldProtected, py2_encode("Protected"))
+        self.assertEqual(test.fieldPrivate, py2_encode("Private"))
+
+        self.assertTrue(hasattr(test, 'fieldChildPublic'))
+        self.assertTrue(hasattr(test, 'fieldChildProtected'))
+        self.assertTrue(hasattr(test, 'fieldChildPrivate'))
+
+        self.assertEqual(test.fieldChildPublic, py2_encode("ChildPublic"))
+        self.assertEqual(test.fieldChildProtected, py2_encode("ChildProtected"))
+        self.assertEqual(test.fieldChildPrivate, py2_encode("ChildPrivate"))
+
+    def test_methods_all(self):
         Test = autoclass('org.jnius.VisibilityTest', include_protected=True, include_private=True)
         test = Test()
 
@@ -71,3 +126,36 @@ class VisibilityAllTest(unittest.TestCase):
         self.assertEqual(test.methodPublic(), py2_encode("Public"))
         self.assertEqual(test.methodProtected(), py2_encode("Protected"))
         self.assertEqual(test.methodPrivate(), py2_encode("Private"))
+
+    def test_child_methods_all(self):
+        Test = autoclass('org.jnius.ChildVisibilityTest', include_protected=True, include_private=True)
+        test = Test()
+
+        self.assertTrue(hasattr(test, 'methodChildPublic'))
+        self.assertTrue(hasattr(test, 'methodChildProtected'))
+        self.assertTrue(hasattr(test, 'methodChildPrivate'))
+
+        self.assertEqual(test.methodChildPublic(), py2_encode("ChildPublic"))
+        self.assertEqual(test.methodChildProtected(), py2_encode("ChildProtected"))
+        self.assertEqual(test.methodChildPrivate(), py2_encode("ChildPrivate"))
+
+    def test_static_multi_methods(self):
+        Test = autoclass('org.jnius.ChildVisibilityTest', include_protected=True, include_private=True)
+
+        self.assertTrue(hasattr(Test, 'methodStaticMultiArgs'))
+        self.assertTrue(isinstance(Test.methodStaticMultiArgs, JavaMultipleMethod))
+
+        self.assertTrue(Test.methodStaticMultiArgs(True))
+        self.assertTrue(Test.methodStaticMultiArgs(True, False))
+        self.assertTrue(Test.methodStaticMultiArgs(True, False, True))
+
+    def test_multi_methods(self):
+        Test = autoclass('org.jnius.ChildVisibilityTest', include_protected=True, include_private=True)
+        test = Test()
+
+        self.assertTrue(hasattr(test, 'methodMultiArgs'))
+        self.assertTrue(isinstance(Test.methodMultiArgs, JavaMultipleMethod))
+
+        self.assertTrue(test.methodMultiArgs(True))
+        self.assertTrue(test.methodMultiArgs(True, False))
+        self.assertTrue(test.methodMultiArgs(True, False, True))

--- a/tests/test_visibility_public_only.py
+++ b/tests/test_visibility_public_only.py
@@ -3,7 +3,10 @@ from __future__ import division
 from __future__ import absolute_import
 import sys
 import unittest
+import jnius_config
+from jnius import JavaMethod, JavaStaticMethod, JavaException
 from jnius.reflect import autoclass
+
 
 try:
     long
@@ -20,7 +23,7 @@ def py2_encode(uni):
 
 class VisibilityPublicOnlyTest(unittest.TestCase):
 
-    def test_static_fields_public(self):
+    def test_static_fields_public_only(self):
         Test = autoclass('org.jnius.VisibilityTest', include_protected=False, include_private=False)
 
         self.assertTrue(hasattr(Test, 'fieldStaticPublic'))
@@ -29,7 +32,22 @@ class VisibilityPublicOnlyTest(unittest.TestCase):
 
         self.assertEqual(Test.fieldStaticPublic, py2_encode("StaticPublic"))
 
-    def test_static_methods_public(self):
+    def test_child_static_fields_public_only(self):
+        Test = autoclass('org.jnius.ChildVisibilityTest', include_protected=False, include_private=False)
+
+        self.assertTrue(hasattr(Test, 'fieldStaticPublic'))
+        self.assertFalse(hasattr(Test, 'fieldStaticProtected'))
+        self.assertFalse(hasattr(Test, 'fieldStaticPrivate'))
+
+        self.assertEqual(Test.fieldStaticPublic, py2_encode("StaticPublic"))
+
+        self.assertTrue(hasattr(Test, 'fieldChildStaticPublic'))
+        self.assertFalse(hasattr(Test, 'fieldChildStaticProtected'))
+        self.assertFalse(hasattr(Test, 'fieldChildStaticPrivate'))
+
+        self.assertEqual(Test.fieldChildStaticPublic, py2_encode("ChildStaticPublic"))
+
+    def test_static_methods_public_only(self):
         Test = autoclass('org.jnius.VisibilityTest', include_protected=False, include_private=False)
 
         self.assertTrue(hasattr(Test, 'methodStaticPublic'))
@@ -38,22 +56,92 @@ class VisibilityPublicOnlyTest(unittest.TestCase):
 
         self.assertEqual(Test.methodStaticPublic(), py2_encode("StaticPublic"))
 
-    def test_fields_public(self):
+    def test_child_static_methods_public_only(self):
+        Test = autoclass('org.jnius.ChildVisibilityTest', include_protected=False, include_private=False)
+
+        self.assertTrue(hasattr(Test, 'methodStaticPublic'))
+        self.assertFalse(hasattr(Test, 'methodStaticProtected'))
+        self.assertFalse(hasattr(Test, 'methodStaticPrivate'))
+
+        self.assertEqual(Test.methodStaticPublic(), py2_encode("StaticPublic"))
+
+        self.assertTrue(hasattr(Test, 'methodChildStaticPublic'))
+        self.assertFalse(hasattr(Test, 'methodChildStaticProtected'))
+        self.assertFalse(hasattr(Test, 'methodChildStaticPrivate'))
+
+        self.assertEqual(Test.methodChildStaticPublic(), py2_encode("ChildStaticPublic"))
+
+    def test_fields_public_only(self):
+
         Test = autoclass('org.jnius.VisibilityTest', include_protected=False, include_private=False)
-        public_only_test = Test()
+        test = Test()
 
-        self.assertTrue(hasattr(public_only_test, 'fieldPublic'))
-        self.assertFalse(hasattr(public_only_test, 'fieldProtected'))
-        self.assertFalse(hasattr(public_only_test, 'fieldPrivate'))
+        self.assertTrue(hasattr(test, 'fieldPublic'))
+        self.assertFalse(hasattr(test, 'fieldProtected'))
+        self.assertFalse(hasattr(test, 'fieldPrivate'))
 
-        self.assertEqual(public_only_test.fieldPublic, py2_encode("Public"))
+        self.assertEqual(test.fieldPublic, py2_encode("Public"))
 
-    def test_methods_public(self):
+    def test_child_fields_public_only(self):
+
+        Test = autoclass('org.jnius.ChildVisibilityTest', include_protected=False, include_private=False)
+        test = Test()
+
+        self.assertTrue(hasattr(test, 'fieldPublic'))
+        self.assertFalse(hasattr(test, 'fieldProtected'))
+        self.assertFalse(hasattr(test, 'fieldPrivate'))
+
+        self.assertEqual(test.fieldPublic, py2_encode("Public"))
+
+        self.assertTrue(hasattr(test, 'fieldChildPublic'))
+        self.assertFalse(hasattr(test, 'fieldChildProtected'))
+        self.assertFalse(hasattr(test, 'fieldChildPrivate'))
+
+        self.assertEqual(test.fieldChildPublic, py2_encode("ChildPublic"))
+
+    def test_methods_public_only(self):
+
         Test = autoclass('org.jnius.VisibilityTest', include_protected=False, include_private=False)
-        public_only_test = Test()
+        test = Test()
 
-        self.assertTrue(hasattr(public_only_test, 'methodPublic'))
-        self.assertFalse(hasattr(public_only_test, 'methodProtected'))
-        self.assertFalse(hasattr(public_only_test, 'methodPrivate'))
+        self.assertTrue(hasattr(test, 'methodPublic'))
+        self.assertFalse(hasattr(test, 'methodProtected'))
+        self.assertFalse(hasattr(test, 'methodPrivate'))
 
-        self.assertEqual(public_only_test.methodPublic(), py2_encode("Public"))
+        self.assertEqual(test.methodPublic(), py2_encode("Public"))
+
+    def test_child_methods_public_only(self):
+
+        Test = autoclass('org.jnius.ChildVisibilityTest', include_protected=False, include_private=False)
+        test = Test()
+
+        self.assertTrue(hasattr(test, 'methodChildPublic'))
+        self.assertFalse(hasattr(test, 'methodChildProtected'))
+        self.assertFalse(hasattr(test, 'methodChildPrivate'))
+
+        self.assertEqual(test.methodChildPublic(), py2_encode("ChildPublic"))
+
+    def test_static_multi_methods(self):
+        Test = autoclass('org.jnius.ChildVisibilityTest', include_protected=False, include_private=False)
+
+        self.assertTrue(hasattr(Test, 'methodStaticMultiArgs'))
+        self.assertTrue(isinstance(Test.methodStaticMultiArgs, JavaStaticMethod))
+
+        self.assertTrue(Test.methodStaticMultiArgs(True))
+        with self.assertRaises(JavaException):
+            Test.methodStaticMultiArgs(True, False)
+        with self.assertRaises(JavaException):
+            Test.methodStaticMultiArgs(True, False, True)
+
+    def test_multi_methods(self):
+        Test = autoclass('org.jnius.ChildVisibilityTest', include_protected=False, include_private=False)
+        test = Test()
+
+        self.assertTrue(hasattr(test, 'methodMultiArgs'))
+        self.assertTrue(isinstance(Test.methodMultiArgs, JavaMethod))
+
+        self.assertTrue(test.methodMultiArgs(True))
+        with self.assertRaises(JavaException):
+            test.methodMultiArgs(True, False)
+        with self.assertRaises(JavaException):
+           test.methodMultiArgs(True, False, True)

--- a/tests/test_visibility_public_only.py
+++ b/tests/test_visibility_public_only.py
@@ -21,19 +21,19 @@ def py2_encode(uni):
 class VisibilityPublicOnlyTest(unittest.TestCase):
 
     def test_static_fields_public(self):
-        PublicOnlyTest = autoclass('org.jnius.PublicOnlyTest', public_only=True)
+        PublicOnlyTest = autoclass('org.jnius.VisibilityTest', public_only=True)
 
         self.assertTrue(hasattr(PublicOnlyTest, 'fieldStaticPublic'))
         self.assertFalse(hasattr(PublicOnlyTest, 'fieldStaticProtected'))
         self.assertFalse(hasattr(PublicOnlyTest, 'fieldStaticPrivate'))
 
-        self.assertEqual(PublicOnlyTest.fieldStaticPublic, py2_encode("fieldStaticPublic"))
+        self.assertEqual(PublicOnlyTest.fieldStaticPublic, py2_encode("StaticPublic"))
 
     def test_static_methods_public(self):
-        PublicOnlyTest = autoclass('org.jnius.PublicOnlyTest', public_only=True)
+        PublicOnlyTest = autoclass('org.jnius.VisibilityTest', public_only=True)
 
         self.assertTrue(hasattr(PublicOnlyTest, 'methodStaticPublic'))
         self.assertFalse(hasattr(PublicOnlyTest, 'methodStaticProtected'))
         self.assertFalse(hasattr(PublicOnlyTest, 'methodStaticPrivate'))
 
-        self.assertEqual(PublicOnlyTest.methodStaticPublic(), py2_encode("methodStaticPublic"))
+        self.assertEqual(PublicOnlyTest.methodStaticPublic(), py2_encode("StaticPublic"))

--- a/tests/test_visibility_public_only.py
+++ b/tests/test_visibility_public_only.py
@@ -37,3 +37,23 @@ class VisibilityPublicOnlyTest(unittest.TestCase):
         self.assertFalse(hasattr(PublicOnlyTest, 'methodStaticPrivate'))
 
         self.assertEqual(PublicOnlyTest.methodStaticPublic(), py2_encode("StaticPublic"))
+
+    def test_fields_public(self):
+        PublicOnlyTest = autoclass('org.jnius.VisibilityTest', public_only=True)
+        public_only_test = PublicOnlyTest()
+
+        self.assertTrue(hasattr(public_only_test, 'fieldPublic'))
+        self.assertFalse(hasattr(public_only_test, 'fieldProtected'))
+        self.assertFalse(hasattr(public_only_test, 'fieldPrivate'))
+
+        self.assertEqual(public_only_test.fieldPublic, py2_encode("Public"))
+
+    def test_methods_public(self):
+        PublicOnlyTest = autoclass('org.jnius.VisibilityTest', public_only=True)
+        public_only_test = PublicOnlyTest()
+
+        self.assertTrue(hasattr(public_only_test, 'methodPublic'))
+        self.assertFalse(hasattr(public_only_test, 'methodProtected'))
+        self.assertFalse(hasattr(public_only_test, 'methodPrivate'))
+
+        self.assertEqual(public_only_test.methodPublic(), py2_encode("Public"))

--- a/tests/test_visibility_public_only.py
+++ b/tests/test_visibility_public_only.py
@@ -1,0 +1,39 @@
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
+import sys
+import unittest
+from jnius.reflect import autoclass
+
+try:
+    long
+except NameError:
+    # Python 3
+    long = int
+
+
+def py2_encode(uni):
+    if sys.version_info < (3, 0):
+        uni = uni.encode('utf-8')
+    return uni
+
+
+class VisibilityPublicOnlyTest(unittest.TestCase):
+
+    def test_static_fields_public(self):
+        PublicOnlyTest = autoclass('org.jnius.PublicOnlyTest', public_only=True)
+
+        self.assertTrue(hasattr(PublicOnlyTest, 'fieldStaticPublic'))
+        self.assertFalse(hasattr(PublicOnlyTest, 'fieldStaticProtected'))
+        self.assertFalse(hasattr(PublicOnlyTest, 'fieldStaticPrivate'))
+
+        self.assertEqual(PublicOnlyTest.fieldStaticPublic, py2_encode("fieldStaticPublic"))
+
+    def test_static_methods_public(self):
+        PublicOnlyTest = autoclass('org.jnius.PublicOnlyTest', public_only=True)
+
+        self.assertTrue(hasattr(PublicOnlyTest, 'methodStaticPublic'))
+        self.assertFalse(hasattr(PublicOnlyTest, 'methodStaticProtected'))
+        self.assertFalse(hasattr(PublicOnlyTest, 'methodStaticPrivate'))
+
+        self.assertEqual(PublicOnlyTest.methodStaticPublic(), py2_encode("methodStaticPublic"))

--- a/tests/test_visibility_public_only.py
+++ b/tests/test_visibility_public_only.py
@@ -21,7 +21,7 @@ def py2_encode(uni):
 class VisibilityPublicOnlyTest(unittest.TestCase):
 
     def test_static_fields_public(self):
-        PublicOnlyTest = autoclass('org.jnius.VisibilityTest', public_only=True)
+        PublicOnlyTest = autoclass('org.jnius.VisibilityTest', include_protected=False, include_private=False)
 
         self.assertTrue(hasattr(PublicOnlyTest, 'fieldStaticPublic'))
         self.assertFalse(hasattr(PublicOnlyTest, 'fieldStaticProtected'))
@@ -30,7 +30,7 @@ class VisibilityPublicOnlyTest(unittest.TestCase):
         self.assertEqual(PublicOnlyTest.fieldStaticPublic, py2_encode("StaticPublic"))
 
     def test_static_methods_public(self):
-        PublicOnlyTest = autoclass('org.jnius.VisibilityTest', public_only=True)
+        PublicOnlyTest = autoclass('org.jnius.VisibilityTest', include_protected=False, include_private=False)
 
         self.assertTrue(hasattr(PublicOnlyTest, 'methodStaticPublic'))
         self.assertFalse(hasattr(PublicOnlyTest, 'methodStaticProtected'))
@@ -39,7 +39,7 @@ class VisibilityPublicOnlyTest(unittest.TestCase):
         self.assertEqual(PublicOnlyTest.methodStaticPublic(), py2_encode("StaticPublic"))
 
     def test_fields_public(self):
-        PublicOnlyTest = autoclass('org.jnius.VisibilityTest', public_only=True)
+        PublicOnlyTest = autoclass('org.jnius.VisibilityTest', include_protected=False, include_private=False)
         public_only_test = PublicOnlyTest()
 
         self.assertTrue(hasattr(public_only_test, 'fieldPublic'))
@@ -49,7 +49,7 @@ class VisibilityPublicOnlyTest(unittest.TestCase):
         self.assertEqual(public_only_test.fieldPublic, py2_encode("Public"))
 
     def test_methods_public(self):
-        PublicOnlyTest = autoclass('org.jnius.VisibilityTest', public_only=True)
+        PublicOnlyTest = autoclass('org.jnius.VisibilityTest', include_protected=False, include_private=False)
         public_only_test = PublicOnlyTest()
 
         self.assertTrue(hasattr(public_only_test, 'methodPublic'))

--- a/tests/test_visibility_public_protected.py
+++ b/tests/test_visibility_public_protected.py
@@ -3,7 +3,10 @@ from __future__ import division
 from __future__ import absolute_import
 import sys
 import unittest
+import jnius_config
+from jnius import JavaMultipleMethod, JavaException
 from jnius.reflect import autoclass
+
 
 try:
     long
@@ -22,12 +25,30 @@ class VisibilityPublicProtectedTest(unittest.TestCase):
 
     def test_static_fields_public_protected(self):
         Test = autoclass('org.jnius.VisibilityTest', include_protected=True, include_private=False)
+
         self.assertTrue(hasattr(Test, 'fieldStaticPublic'))
         self.assertTrue(hasattr(Test, 'fieldStaticProtected'))
         self.assertFalse(hasattr(Test, 'fieldStaticPrivate'))
 
         self.assertEqual(Test.fieldStaticPublic, py2_encode("StaticPublic"))
         self.assertEqual(Test.fieldStaticProtected, py2_encode("StaticProtected"))
+
+    def test_child_static_fields_public_protected(self):
+        Test = autoclass('org.jnius.ChildVisibilityTest', include_protected=True, include_private=False)
+
+        self.assertTrue(hasattr(Test, 'fieldStaticPublic'))
+        self.assertTrue(hasattr(Test, 'fieldStaticProtected'))
+        self.assertFalse(hasattr(Test, 'fieldStaticPrivate'))
+
+        self.assertEqual(Test.fieldStaticPublic, py2_encode("StaticPublic"))
+        self.assertEqual(Test.fieldStaticProtected, py2_encode("StaticProtected"))
+
+        self.assertTrue(hasattr(Test, 'fieldChildStaticPublic'))
+        self.assertTrue(hasattr(Test, 'fieldChildStaticProtected'))
+        self.assertFalse(hasattr(Test, 'fieldChildStaticPrivate'))
+
+        self.assertEqual(Test.fieldChildStaticPublic, py2_encode("ChildStaticPublic"))
+        self.assertEqual(Test.fieldChildStaticProtected, py2_encode("ChildStaticProtected"))
 
     def test_static_methods_public_protected(self):
         Test = autoclass('org.jnius.VisibilityTest', include_protected=True, include_private=False)
@@ -39,24 +60,97 @@ class VisibilityPublicProtectedTest(unittest.TestCase):
         self.assertEqual(Test.methodStaticPublic(), py2_encode("StaticPublic"))
         self.assertEqual(Test.methodStaticProtected(), py2_encode("StaticProtected"))
 
+    def test_child_static_methods_public_protected(self):
+        Test = autoclass('org.jnius.ChildVisibilityTest', include_protected=True, include_private=False)
+
+        self.assertTrue(hasattr(Test, 'methodStaticPublic'))
+        self.assertTrue(hasattr(Test, 'methodStaticProtected'))
+        self.assertFalse(hasattr(Test, 'methodStaticPrivate'))
+
+        self.assertEqual(Test.methodStaticPublic(), py2_encode("StaticPublic"))
+        self.assertEqual(Test.methodStaticProtected(), py2_encode("StaticProtected"))
+
+        self.assertTrue(hasattr(Test, 'methodChildStaticPublic'))
+        self.assertTrue(hasattr(Test, 'methodChildStaticProtected'))
+        self.assertFalse(hasattr(Test, 'methodChildStaticPrivate'))
+
+        self.assertEqual(Test.methodChildStaticPublic(), py2_encode("ChildStaticPublic"))
+        self.assertEqual(Test.methodChildStaticProtected(), py2_encode("ChildStaticProtected"))
+
     def test_fields_public_protected(self):
+
         Test = autoclass('org.jnius.VisibilityTest', include_protected=True, include_private=False)
-        public_only_test = Test()
+        test = Test()
 
-        self.assertTrue(hasattr(public_only_test, 'fieldPublic'))
-        self.assertTrue(hasattr(public_only_test, 'fieldProtected'))
-        self.assertFalse(hasattr(public_only_test, 'fieldPrivate'))
+        self.assertTrue(hasattr(test, 'fieldPublic'))
+        self.assertTrue(hasattr(test, 'fieldProtected'))
+        self.assertFalse(hasattr(test, 'fieldPrivate'))
 
-        self.assertEqual(public_only_test.fieldPublic, py2_encode("Public"))
-        self.assertEqual(public_only_test.fieldProtected, py2_encode("Protected"))
+        self.assertEqual(test.fieldPublic, py2_encode("Public"))
+        self.assertEqual(test.fieldProtected, py2_encode("Protected"))
+
+    def test_child_fields_public_protected(self):
+
+        Test = autoclass('org.jnius.ChildVisibilityTest', include_protected=True, include_private=False)
+        test = Test()
+
+        self.assertTrue(hasattr(test, 'fieldPublic'))
+        self.assertTrue(hasattr(test, 'fieldProtected'))
+        self.assertFalse(hasattr(test, 'fieldPrivate'))
+
+        self.assertEqual(test.fieldPublic, py2_encode("Public"))
+        self.assertEqual(test.fieldProtected, py2_encode("Protected"))
+
+        self.assertTrue(hasattr(test, 'fieldChildPublic'))
+        self.assertTrue(hasattr(test, 'fieldChildProtected'))
+        self.assertFalse(hasattr(test, 'fieldChildPrivate'))
+
+        self.assertEqual(test.fieldChildPublic, py2_encode("ChildPublic"))
+        self.assertEqual(test.fieldChildProtected, py2_encode("ChildProtected"))
 
     def test_methods_public_protected(self):
+
         Test = autoclass('org.jnius.VisibilityTest', include_protected=True, include_private=False)
-        public_only_test = Test()
+        test = Test()
 
-        self.assertTrue(hasattr(public_only_test, 'methodPublic'))
-        self.assertTrue(hasattr(public_only_test, 'methodProtected'))
-        self.assertFalse(hasattr(public_only_test, 'methodPrivate'))
+        self.assertTrue(hasattr(test, 'methodPublic'))
+        self.assertTrue(hasattr(test, 'methodProtected'))
+        self.assertFalse(hasattr(test, 'methodPrivate'))
 
-        self.assertEqual(public_only_test.methodPublic(), py2_encode("Public"))
-        self.assertEqual(public_only_test.methodProtected(), py2_encode("Protected"))
+        self.assertEqual(test.methodPublic(), py2_encode("Public"))
+        self.assertEqual(test.methodProtected(), py2_encode("Protected"))
+
+    def test_child_methods_public_protected(self):
+
+        Test = autoclass('org.jnius.ChildVisibilityTest', include_protected=True, include_private=False)
+        test = Test()
+
+        self.assertTrue(hasattr(test, 'methodChildPublic'))
+        self.assertTrue(hasattr(test, 'methodChildProtected'))
+        self.assertFalse(hasattr(test, 'methodChildPrivate'))
+
+        self.assertEqual(test.methodChildPublic(), py2_encode("ChildPublic"))
+        self.assertEqual(test.methodChildProtected(), py2_encode("ChildProtected"))
+
+    def test_static_multi_methods(self):
+        Test = autoclass('org.jnius.ChildVisibilityTest', include_protected=True, include_private=False)
+
+        self.assertTrue(hasattr(Test, 'methodStaticMultiArgs'))
+        self.assertTrue(isinstance(Test.methodStaticMultiArgs, JavaMultipleMethod))
+
+        self.assertTrue(Test.methodStaticMultiArgs(True))
+        self.assertTrue(Test.methodStaticMultiArgs(True, False))
+        with self.assertRaises(JavaException):
+            Test.methodStaticMultiArgs(True, False, True)
+
+    def test_multi_methods(self):
+        Test = autoclass('org.jnius.ChildVisibilityTest', include_protected=True, include_private=False)
+        test = Test()
+
+        self.assertTrue(hasattr(test, 'methodMultiArgs'))
+        self.assertTrue(isinstance(Test.methodMultiArgs, JavaMultipleMethod))
+
+        self.assertTrue(test.methodMultiArgs(True))
+        self.assertTrue(test.methodMultiArgs(True, False))
+        with self.assertRaises(JavaException):
+           test.methodMultiArgs(True, False, True)

--- a/tests/test_visibility_public_protected.py
+++ b/tests/test_visibility_public_protected.py
@@ -18,42 +18,45 @@ def py2_encode(uni):
     return uni
 
 
-class VisibilityPublicOnlyTest(unittest.TestCase):
+class VisibilityPublicProtectedTest(unittest.TestCase):
 
-    def test_static_fields_public(self):
-        Test = autoclass('org.jnius.VisibilityTest', include_protected=False, include_private=False)
-
+    def test_static_fields_public_protected(self):
+        Test = autoclass('org.jnius.VisibilityTest', include_protected=True, include_private=False)
         self.assertTrue(hasattr(Test, 'fieldStaticPublic'))
-        self.assertFalse(hasattr(Test, 'fieldStaticProtected'))
+        self.assertTrue(hasattr(Test, 'fieldStaticProtected'))
         self.assertFalse(hasattr(Test, 'fieldStaticPrivate'))
 
         self.assertEqual(Test.fieldStaticPublic, py2_encode("StaticPublic"))
+        self.assertEqual(Test.fieldStaticProtected, py2_encode("StaticProtected"))
 
-    def test_static_methods_public(self):
-        Test = autoclass('org.jnius.VisibilityTest', include_protected=False, include_private=False)
+    def test_static_methods_public_protected(self):
+        Test = autoclass('org.jnius.VisibilityTest', include_protected=True, include_private=False)
 
         self.assertTrue(hasattr(Test, 'methodStaticPublic'))
-        self.assertFalse(hasattr(Test, 'methodStaticProtected'))
+        self.assertTrue(hasattr(Test, 'methodStaticProtected'))
         self.assertFalse(hasattr(Test, 'methodStaticPrivate'))
 
         self.assertEqual(Test.methodStaticPublic(), py2_encode("StaticPublic"))
+        self.assertEqual(Test.methodStaticProtected(), py2_encode("StaticProtected"))
 
-    def test_fields_public(self):
-        Test = autoclass('org.jnius.VisibilityTest', include_protected=False, include_private=False)
+    def test_fields_public_protected(self):
+        Test = autoclass('org.jnius.VisibilityTest', include_protected=True, include_private=False)
         public_only_test = Test()
 
         self.assertTrue(hasattr(public_only_test, 'fieldPublic'))
-        self.assertFalse(hasattr(public_only_test, 'fieldProtected'))
+        self.assertTrue(hasattr(public_only_test, 'fieldProtected'))
         self.assertFalse(hasattr(public_only_test, 'fieldPrivate'))
 
         self.assertEqual(public_only_test.fieldPublic, py2_encode("Public"))
+        self.assertEqual(public_only_test.fieldProtected, py2_encode("Protected"))
 
-    def test_methods_public(self):
-        Test = autoclass('org.jnius.VisibilityTest', include_protected=False, include_private=False)
+    def test_methods_public_protected(self):
+        Test = autoclass('org.jnius.VisibilityTest', include_protected=True, include_private=False)
         public_only_test = Test()
 
         self.assertTrue(hasattr(public_only_test, 'methodPublic'))
-        self.assertFalse(hasattr(public_only_test, 'methodProtected'))
+        self.assertTrue(hasattr(public_only_test, 'methodProtected'))
         self.assertFalse(hasattr(public_only_test, 'methodPrivate'))
 
         self.assertEqual(public_only_test.methodPublic(), py2_encode("Public"))
+        self.assertEqual(public_only_test.methodProtected(), py2_encode("Protected"))


### PR DESCRIPTION
Adding a `public_only` option to the `autoclass` function. When used this can limit the created class to only public methods and fields.
