### PR TITLE
macOS - use /usr/libexec/java_home to detect Java

### DIFF
--- a/jnius/jnius_jvm_dlopen.pxi
+++ b/jnius/jnius_jvm_dlopen.pxi
@@ -2,7 +2,7 @@ include "config.pxi"
 import os
 from shlex import split
 from subprocess import check_output
-from os.path import dirname, join
+from os.path import dirname, join, exists
 from os import readlink
 from sys import platform
 from .env import get_jnius_lib_location
@@ -56,6 +56,14 @@ cdef find_java_home():
             except OSError:
                 break
         return dirname(dirname(java)).decode('utf8')
+    
+    if platform in ('darwin'):
+        #its a mac
+        if not exists('/usr/libexec/java_home'):
+            return
+        java = check_output('/usr/libexec/java_home').strip().decode('utf8')
+        return java
+        
 
 
 cdef void create_jnienv() except *:

--- a/jnius/jnius_jvm_dlopen.pxi
+++ b/jnius/jnius_jvm_dlopen.pxi
@@ -57,13 +57,14 @@ cdef find_java_home():
                 break
         return dirname(dirname(java)).decode('utf8')
     
-    if platform in ('darwin'):
+    if platform == 'darwin':
+        MAC_JAVA_HOME='/usr/libexec/java_home'
         # its a mac
-        if not exists('/usr/libexec/java_home'):
+        if not exists(MAC_JAVA_HOME):
             # I believe this always exists, but just in case
             return
         try:
-            java = check_output('/usr/libexec/java_home').strip().decode('utf8')
+            java = check_output(MAC_JAVA_HOME).strip().decode('utf8')
             return java
         except CalledProcessError as exc:
             # java_home return non-zero exit code if no Javas are installed

--- a/jnius/jnius_jvm_dlopen.pxi
+++ b/jnius/jnius_jvm_dlopen.pxi
@@ -1,7 +1,7 @@
 include "config.pxi"
 import os
 from shlex import split
-from subprocess import check_output
+from subprocess import check_output, CalledProcessError
 from os.path import dirname, join, exists
 from os import readlink
 from sys import platform
@@ -58,11 +58,16 @@ cdef find_java_home():
         return dirname(dirname(java)).decode('utf8')
     
     if platform in ('darwin'):
-        #its a mac
+        # its a mac
         if not exists('/usr/libexec/java_home'):
+            # I believe this always exists, but just in case
             return
-        java = check_output('/usr/libexec/java_home').strip().decode('utf8')
-        return java
+        try:
+            java = check_output('/usr/libexec/java_home').strip().decode('utf8')
+            return java
+        except CalledProcessError as exc:
+            # java_home return non-zero exit code if no Javas are installed
+            return
         
 
 


### PR DESCRIPTION
Avoids setting JAVA_HOME if possible on macOs