### PR TITLE
reading static fields from instances, and writing to static fields

### DIFF
--- a/tests/java-src/org/jnius/Parent.java
+++ b/tests/java-src/org/jnius/Parent.java
@@ -2,6 +2,8 @@ package org.jnius;
 
 public class Parent {
 
+	public static int STATIC_PARENT_FIELD = 1;
+
 	public int doCall(Object o) {
 		return 0;
 	}

--- a/tests/test_inheritance.py
+++ b/tests/test_inheritance.py
@@ -1,7 +1,7 @@
-from jnius import autoclass
 
 
 def test_methodcalls():
+    from jnius import autoclass
     Parent = autoclass('org.jnius.Parent')
     Child = autoclass('org.jnius.Child')
     child = Child.newInstance()
@@ -11,6 +11,7 @@ def test_methodcalls():
     assert child.doCall(child) == 0
 
 def test_fields():
+    from jnius import autoclass
     Parent = autoclass('org.jnius.Parent')
     Child = autoclass('org.jnius.Child')
     child = Child.newInstance()
@@ -18,9 +19,27 @@ def test_fields():
     assert parent.PARENT_FIELD == 0
     assert child.CHILD_FIELD == 1
     assert child.PARENT_FIELD == 0
-    
+
+def test_staticfields():
+    from jnius import autoclass
+    Parent = autoclass('org.jnius.Parent')
+    Child = autoclass('org.jnius.Child')
+    child = Child.newInstance()
+    parent = Parent.newInstance()
+    assert Parent.STATIC_PARENT_FIELD == 1
+    assert Child.STATIC_PARENT_FIELD == 1
+    assert parent.STATIC_PARENT_FIELD == 1
+    assert child.STATIC_PARENT_FIELD == 1
+    #now test setting
+    Parent.STATIC_PARENT_FIELD = 5
+    assert Parent.STATIC_PARENT_FIELD == 5
+    assert parent.STATIC_PARENT_FIELD == 5
+    #assert Child.STATIC_PARENT_FIELD == 5
+    #assert child.STATIC_PARENT_FIELD == 5
+
 
 def test_newinstance():
+    from jnius import autoclass
     Parent = autoclass('org.jnius.Parent')
     Child = autoclass('org.jnius.Child')
 
@@ -29,4 +48,7 @@ def test_newinstance():
     assert isinstance(child, Parent)
 
 if __name__ == "__main__":
+    import jnius_config
+    jnius_config.add_options('-Xcheck:jni')
     test_newinstance()
+


### PR DESCRIPTION
this addresses the reading of static fields from instances discussed in #500. 
It also addresses the writing to static fields, which was not implemented. 

Writing works when accessing the member variable itself, but the commented out lines in the test case do not, in that the the initial value of the field in child and Child are unchanged.
```python
    Parent.STATIC_PARENT_FIELD = 5
    assert Parent.STATIC_PARENT_FIELD == 5
    assert parent.STATIC_PARENT_FIELD == 5
    #assert Child.STATIC_PARENT_FIELD == 5
    #assert child.STATIC_PARENT_FIELD == 5
```

I dont think this is related to #500. 
Similarly, we can set in the child, and it doesn't propagate to the parent class.
```python
    Child.STATIC_PARENT_FIELD = 10
    assert Child.STATIC_PARENT_FIELD == 10
    assert child.STATIC_PARENT_FIELD == 10
    #assert Parent.STATIC_PARENT_FIELD == 10
    #assert parent.STATIC_PARENT_FIELD == 10
```

This clearly contrasts with Java, as per jshell:
```
$ CLASSPATH=build/classes/:build/test-classes jshell                          

jshell> org.jnius.Parent.STATIC_PARENT_FIELD = 5
$1 ==> 5

jshell> org.jnius.Child.STATIC_PARENT_FIELD
$2 ==> 5

jshell> org.jnius.Child.STATIC_PARENT_FIELD = 10
$3 ==> 10

jshell> org.jnius.Child.STATIC_PARENT_FIELD
$4 ==> 10
```

I'm wondering if _we_ need to keep track of the object that the static field belongs to...

So in short, this solves two bugs, but demonstrates a third. 
@tshirtman  @hx2A
