### PR TITLE
implements more dunder protocols 

### DIFF
--- a/jnius/reflect.py
+++ b/jnius/reflect.py
@@ -339,17 +339,58 @@ def _getitem(self, index):
         else:
             raise
 
+#dunder method for java.util.Map
+def _map_getitem(self, k):
+    rtr = self.get(k)
+    if rtr is None:
+        raise KeyError()
+    return rtr
+
+#dunder method for java.util.Iterator
+def _iterator_next(self):
+    if not self.hasNext():
+        raise StopIteration()
+    return self.next()
+
+
 # protocol_map is a user-accessible API for patching class instances with additional methods 
 protocol_map = {
     'java.util.Collection' : {
-        '__len__' : lambda self: self.size()
+        '__len__' : lambda self: self.size(),
+        '__contains__' : lambda self, item: self.contains(item),
+        '__delitem__' : lambda self, item: self.remove(item)
     },
     'java.util.List' : {
         '__getitem__' : _getitem        
+    },
+    'java.util.Map' : {
+        '__setitem__' : lambda self, k, v : self.put(k,v),
+        '__getitem__' : _map_getitem,
+        '__delitem__' : lambda self, item: self.remove(item),
+        '__len__' : lambda self: self.size(),
+        '__contains__' : lambda self, item: self.containsKey(item),
+        '__iter__' : lambda self: self.keySet().iterator()
+    },
+    'java.util.Iterator' : {
+        '__iter__' : lambda self: self,
+        '__next__' : _iterator_next
+    },
+    'java.lang.Iterable' : {
+        '__iter__' : lambda self: self.iterator(),
     },
     # this also addresses java.io.Closeable
     'java.lang.AutoCloseable' : {
         '__enter__' : lambda self: self,
         '__exit__' : lambda self, type, value, traceback: self.close()
+    },
+    'java.lang.Comparable' : {
+        #__cmp__ is for Python 2 support
+        '__cmp__' : lambda self, other: self.compareTo(other),
+        '__eq__' : lambda self, other: self.equals(other),
+        '__ne__' : lambda self, other: not self.equals(other),
+        '__lt__' : lambda self, other: self.compareTo(other) < 0,
+        '__gt__' : lambda self, other: self.compareTo(other) > 0,
+        '__le__' : lambda self, other: self.compareTo(other) <= 0,
+        '__ge__' : lambda self, other: self.compareTo(other) >= 0,
     }
 }

--- a/jnius/reflect.py
+++ b/jnius/reflect.py
@@ -324,9 +324,8 @@ def autoclass(clsname):
         (JavaClass, ),
         classDict)
 
-
-## dunder method for List
 def _getitem(self, index):
+    ''' dunder method for List '''
     try:
         return self.get(index)
     except JavaException as e:
@@ -339,19 +338,18 @@ def _getitem(self, index):
         else:
             raise
 
-#dunder method for java.util.Map
 def _map_getitem(self, k):
+    ''' dunder method for java.util.Map '''
     rtr = self.get(k)
     if rtr is None:
         raise KeyError()
     return rtr
 
-#dunder method for java.util.Iterator
 def _iterator_next(self):
+    ''' dunder method for java.util.Iterator'''
     if not self.hasNext():
         raise StopIteration()
     return self.next()
-
 
 # protocol_map is a user-accessible API for patching class instances with additional methods 
 protocol_map = {

--- a/tests/test_arraylist.py
+++ b/tests/test_arraylist.py
@@ -5,6 +5,18 @@ from jnius import autoclass
 
 class ArrayListTest(unittest.TestCase):
 
+    def test_other_dunders(self):
+        alist = autoclass('java.util.ArrayList')()
+        args = [1,2]
+        for arg in args:
+            alist.add(arg)
+        self.assertEqual(len(args), len(alist))
+        for idx, arg in enumerate(args):
+            self.assertTrue(arg in alist)
+        del(alist[1])
+        del(alist[0])
+        self.assertEqual(0, len(alist))
+
     def test_output(self):
         alist = autoclass('java.util.ArrayList')()
         args = [0, 1, 5, -1, -5, 0.0, 1.0, 5.0, -1.0, -5.0, True, False]

--- a/tests/test_collections.py
+++ b/tests/test_collections.py
@@ -5,9 +5,6 @@ from jnius import autoclass, protocol_map
 
 class TestCollections(unittest.TestCase):
 
-    def __init__(self, *args, **kwargs):
-        super(TestCollections, self).__init__(*args, **kwargs)
-
     def test_hashset(self):
         hset = autoclass('java.util.HashSet')()
         data = {1,2}

--- a/tests/test_collections.py
+++ b/tests/test_collections.py
@@ -1,0 +1,55 @@
+from __future__ import absolute_import
+import unittest
+from jnius import autoclass, protocol_map
+
+
+class TestCollections(unittest.TestCase):
+
+    def __init__(self, *args, **kwargs):
+        super(TestCollections, self).__init__(*args, **kwargs)
+
+    def test_hashset(self):
+        hset = autoclass('java.util.HashSet')()
+        data = {1,2}
+        # add is in both Python and Java
+        for k in data:
+            hset.add(k)
+        # __len__
+        print(dir(hset))
+        self.assertEqual(len(data), len(hset))
+        # __contains__
+        for k in data:
+            self.assertTrue(k in hset)
+        self.assertFalse(0 in hset)
+        # __iter__
+        for k in hset:
+            self.assertTrue(k in data)
+        # __delitem__
+        for k in data:
+            del(hset[k])
+            self.assertFalse(k in hset)
+        
+    def test_hashmap(self):
+        hmap = autoclass('java.util.HashMap')()
+        data = {1 : 'hello', 2 : 'world'}
+        # __setitem__
+        for k,v in data.items():
+            hmap[k] = v
+        # __len__
+        self.assertEqual(len(data), len(hmap))
+        # __contains__
+        for k,v in data.items():
+            self.assertTrue(k in hmap)
+            self.assertEqual(data[k], hmap[k])
+        # __iter__
+        for k in hmap:
+           self.assertTrue(k in data)
+        # __contains__
+        self.assertFalse(0 in hmap)
+        # __delitem__
+        for k in data:
+            del(hmap[k])
+            self.assertFalse(k in hmap)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_comparable.py
+++ b/tests/test_comparable.py
@@ -1,0 +1,22 @@
+from __future__ import absolute_import
+import unittest
+from jnius import autoclass, protocol_map
+
+class ComparableTest(unittest.TestCase):
+    def __init__(self, *args, **kwargs):
+        super(ComparableTest, self).__init__(*args, **kwargs)
+    
+    def test_compare_integer(self):
+        five = autoclass('java.lang.Integer')(5)
+        six = autoclass('java.lang.Integer')(6)
+        six_two = autoclass('java.lang.Integer')(6)
+        self.assertTrue(five < six)
+        self.assertTrue(six > five)
+        self.assertTrue(six == six_two)
+        self.assertTrue(five <= six)
+        self.assertTrue(six >= five)
+        self.assertTrue(six >= six_two)
+        self.assertTrue(six <= six_two)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Inspired by https://github.com/kivy/pyjnius/issues/494#issuecomment-611511123, this PR has more support for Java Collections Framework, Iterators, Iterable and Comparable

I worked from https://rszalski.github.io/magicmethods/. Various test cases included.

Ones I didn't implement:
 - `__hash__(self)` - we couldnt guarentee the Python contract of hashCode() vs equals() wouldnt have been implemented on the Java side, as [Comparable](https://docs.oracle.com/javase/8/docs/api/java/lang/Comparable.html) doesnt require it.
 - `__nonzero__(self)` -   java.lang.Boolean (etc) are automapped  anyway
- `__str__(self)` - this could be mapped this to  toString(), but it was still handy in Python to know the jnius representation, i.e. that its a wrapper object.

I haven't verified on Python versions other than 3.6 and Java versions other than 13, so would appreciate the github workflow being run on this PR.