### PR TITLE
Let the check_exception handler raise the error with more details.

### DIFF
--- a/jnius/jnius_export_func.pxi
+++ b/jnius/jnius_export_func.pxi
@@ -23,10 +23,6 @@ def find_javaclass(namestr):
     cdef JNIEnv *j_env = get_jnienv()
 
     jc = j_env[0].FindClass(j_env, name)
-    if jc == NULL:
-        j_env[0].ExceptionClear(j_env)
-        raise JavaException('Class not found {0!r}'.format(name))
-
     check_exception(j_env)
 
     cls = Class(noinstance=True)


### PR DESCRIPTION
I've been getting an error loading NativeInvocationHandler class using autoclass in the latest py3+webview bootstrap code for p4a, but the error message didn't contain many details. After investigating, I realized `check_exception` would give me those details, but the code was raising an exception manually before calling that function. 

This PR changes `find_javaclass` to return the exception generated by `catch_exception` instead of the currently thrown error.

