### PR TITLE
make signature exception more useful

### DIFF
--- a/jnius/jnius_export_class.pxi
+++ b/jnius/jnius_export_class.pxi
@@ -792,7 +792,7 @@ cdef class JavaMethod(object):
 
         if self.j_method == NULL:
             raise JavaException('Unable to find the method'
-                    ' {0}({1})'.format(self.name, self.definition))
+                    ' {0}({1}) in {2}'.format(self.name, self.definition, self.classname))
 
     cdef void set_resolve_info(self, JNIEnv *j_env, jclass j_cls,
             LocalRef j_self, name, classname):
@@ -823,7 +823,9 @@ cdef class JavaMethod(object):
         if len(args) != d_args_len:
             raise JavaException(
                 'Invalid call, number of argument mismatch, '
-                'got {} need {}'.format(len(args), d_args_len)
+                'got {} need {}, found definitions {} in class {} method {}'.format(
+                    len(args), d_args_len, str(self.definition_args),
+                    self.classname, self.name) 
             )
 
         if not self.is_static and j_env == NULL:
@@ -1117,7 +1119,8 @@ cdef class JavaMultipleMethod(object):
 
         if not scores:
             raise JavaException(
-                'No methods matching your arguments, available: {}'.format(
+                'No methods matching your arguments, requested: {}, available: {}'.format(
+                    args,
                     found_signatures
                 )
             )


### PR DESCRIPTION

before:
```
E   jnius.JavaException: No methods matching your arguments, available: ['(Ljava/util/List;Ljava/util/Comparator;)V', '(Ljava/util/List;)V']
```

after:
```
E   jnius.JavaException: No methods matching your arguments, requested: (<java.util.ArrayList at 0x10d6a2c50 jclass=java/util/ArrayList jself=<LocalRef obj=0x7fb9d06c4c00 at 0x12e644210>>, <function TestLambdas.testComparator.<locals>.<lambda> at 0x10d5be158>), available: ['(Ljava/util/List;Ljava/util/Comparator;)V', '(Ljava/util/List;)V']
```