### PR TITLE
ensure autoclass prefers methods over properties

### DIFF
--- a/jnius/reflect.py
+++ b/jnius/reflect.py
@@ -303,6 +303,8 @@ def autoclass(clsname, include_protected=True, include_private=True):
             if log.isEnabledFor(DEBUG):
                 log_method(method, name, sig)
             classDict[name] = (JavaStaticMethod if static else JavaMethod)(sig, varargs=varargs)
+            # methods that fit the characteristics of a JavaBean's methods get turned into properties.
+            # these added properties should not supercede any other methods or fields.
             if name != 'getClass' and bean_getter(name) and len(method.getParameterTypes()) == 0:
                 lowername = lower_name(name[2 if name.startswith('is') else 3:])
                 if lowername in classDict:

--- a/jnius/reflect.py
+++ b/jnius/reflect.py
@@ -305,6 +305,9 @@ def autoclass(clsname, include_protected=True, include_private=True):
             classDict[name] = (JavaStaticMethod if static else JavaMethod)(sig, varargs=varargs)
             if name != 'getClass' and bean_getter(name) and len(method.getParameterTypes()) == 0:
                 lowername = lower_name(name[2 if name.startswith('is') else 3:])
+                if lowername in classDict:
+                    # don't add this to classDict if the property will replace a method or field.
+                    continue
                 classDict[lowername] = (lambda n: property(lambda self: getattr(self, n)()))(name)
         else:
             # multiple signatures

--- a/tests/test_visibility_all.py
+++ b/tests/test_visibility_all.py
@@ -4,7 +4,7 @@ from __future__ import absolute_import
 import sys
 import unittest
 import jnius_config
-from jnius import JavaMultipleMethod
+from jnius import JavaMultipleMethod, JavaMethod
 from jnius.reflect import autoclass
 
 
@@ -181,3 +181,25 @@ class VisibilityAllTest(unittest.TestCase):
 
         al = autoclass("java.util.ArrayList", include_protected=True, include_private=True)()
         assert_is_method(al, 'size')
+
+    def test_check_method_vs_property(self):
+        """check that "bean" properties don't replace methods.
+
+        The ExecutorService Interface has methods `shutdown()`,  `isShutdown()`,
+        `isTerminated()`. The `autoclass` function will create a Python
+        `property` if a function name matches a JavaBean name pattern. Those
+        properties are important but they should not take priority over a
+        method.
+
+        For this Interface it wants to create properties called `shutdown` and
+        `terminated` because of `isShutdown` and `isTerminated`. A `shutdown`
+        property would conflict with the `shutdown()` method so it should be
+        skipped. The `terminated` property is OK though.
+        """
+        executor = autoclass("java.util.concurrent.Executors")
+        pool = executor.newFixedThreadPool(1)
+
+        self.assertTrue(isinstance(pool.__class__.__dict__['shutdown'], JavaMethod))
+        self.assertTrue(isinstance(pool.__class__.__dict__['terminated'], property))
+        self.assertTrue(isinstance(pool.__class__.__dict__['isShutdown'], JavaMethod))
+        self.assertTrue(isinstance(pool.__class__.__dict__['isTerminated'], JavaMethod))


### PR DESCRIPTION
Here is the PR for the problem with the ExecutorService Interface noted in #500.

Created one unit test to validate the JavaBean style properties do not replace a Java method.