### PR TITLE
Always show the Java exception name

### DIFF
--- a/jnius/jnius_utils.pxi
+++ b/jnius/jnius_utils.pxi
@@ -88,7 +88,7 @@ cdef void check_exception(JNIEnv *j_env) except *:
             j_env[0].DeleteLocalRef(j_env, e_msg)
         j_env[0].DeleteLocalRef(j_env, exc)
 
-        raise JavaException('JVM exception occurred: %s' % (pymsg if pymsg is not None else pyexcclass), pyexcclass, pymsg, pystack)
+        raise JavaException('JVM exception occurred: %s' % (pymsg + " " + str(pyexcclass) if pymsg is not None else pyexcclass), pyexcclass, pymsg, pystack)
 
 
 cdef void _append_exception_trace_messages(


### PR DESCRIPTION
The Java exception is never shown, but it is available in the exception class. Here is a patch to make it shown.

Example Usecase: 
Before
`E   jnius.JavaException: JVM exception occurred: org/jnius/ObjectArgument`
After
`E   jnius.JavaException: JVM exception occurred: org/jnius/ObjectArgument java.lang.NoClassDefFoundError`

The first is not clear what the problem is, while the second reminds me that I need to set the CLASSPATH before running pytest.