### PR TITLE
consider "package protected" methods and fields in autoclass

### DIFF
--- a/jnius/reflect.py
+++ b/jnius/reflect.py
@@ -95,12 +95,6 @@ class Modifier(with_metaclass(MetaJavaClass, JavaClass)):
     isTransient = JavaStaticMethod('(I)Z')
     isVolatile = JavaStaticMethod('(I)Z')
 
-    @classmethod
-    def isPackageProtected(cls, modifier):
-        return not (Modifier.isPublic(modifier) or
-                    Modifier.isProtected(modifier) or
-                    Modifier.isPrivate(modifier))
-
 
 class Method(with_metaclass(MetaJavaClass, JavaClass)):
     __javaclass__ = 'java/lang/reflect/Method'
@@ -273,7 +267,9 @@ def autoclass(clsname, include_protected=True, include_private=True):
                 continue
             if Modifier.isPrivate(method_modifier) and not include_private:
                 continue
-            if Modifier.isPackageProtected(method_modifier):
+            if not (Modifier.isPublic(method_modifier) or
+                    Modifier.isProtected(method_modifier) or
+                    Modifier.isPrivate(method_modifier)):
                 if cls_start_packagename == cls_packagename and not include_protected:
                     continue
                 if cls_start_packagename != cls_packagename and not include_private:
@@ -300,7 +296,9 @@ def autoclass(clsname, include_protected=True, include_private=True):
             continue
         if Modifier.isPrivate(field_modifier) and not include_private:
             continue
-        if Modifier.isPackageProtected(field_modifier):
+        if not (Modifier.isPublic(field_modifier) or
+                Modifier.isProtected(field_modifier) or
+                Modifier.isPrivate(field_modifier)):
             if cls_start_packagename == cls_packagename and not include_protected:
                 continue
             if cls_start_packagename != cls_packagename and not include_private:

--- a/jnius/reflect.py
+++ b/jnius/reflect.py
@@ -273,8 +273,11 @@ def autoclass(clsname, include_protected=True, include_private=True):
                 continue
             if Modifier.isPrivate(method_modifier) and not include_private:
                 continue
-            if Modifier.isPackageProtected(method_modifier) and not include_protected and cls_start_packagename != cls_packagename:
-                continue
+            if Modifier.isPackageProtected(method_modifier):
+                if cls_start_packagename == cls_packagename and not include_protected:
+                    continue
+                if cls_start_packagename != cls_packagename and not include_private:
+                    continue
             name = methods_name[index]
             cls_methods[name].append((cls, method, level))
     
@@ -297,8 +300,11 @@ def autoclass(clsname, include_protected=True, include_private=True):
             continue
         if Modifier.isPrivate(field_modifier) and not include_private:
             continue
-        if Modifier.isPackageProtected(field_modifier) and not include_protected and cls_start_packagename != cls_packagename:
-            continue
+        if Modifier.isPackageProtected(field_modifier):
+            if cls_start_packagename == cls_packagename and not include_protected:
+                continue
+            if cls_start_packagename != cls_packagename and not include_private:
+                continue
         cls = JavaStaticField if static else JavaField
         classDict[field_name] = cls(sig)
 

--- a/tests/java-src/org/jnius/VisibilityTest.java
+++ b/tests/java-src/org/jnius/VisibilityTest.java
@@ -4,15 +4,21 @@ import java.lang.String;
 
 public class VisibilityTest {
     public String fieldPublic = "Public";
+    String fieldPackageProtected = "PackageProtected";
     protected String fieldProtected = "Protected";
     private String fieldPrivate = "Private";
 
     static public String fieldStaticPublic = "StaticPublic";
+    static String fieldStaticPackageProtected = "StaticPackageProtected";
     static protected String fieldStaticProtected = "StaticProtected";
     static private String fieldStaticPrivate = "StaticPrivate";
 
     public String methodPublic() {
         return fieldPublic;
+    }
+
+    String methodPackageProtected() {
+        return fieldPackageProtected;
     }
 
     protected String methodProtected() {
@@ -34,6 +40,10 @@ public class VisibilityTest {
 
     static public String methodStaticPublic() {
         return fieldStaticPublic;
+    }
+
+    static String methodStaticPackageProtected() {
+        return fieldStaticPackageProtected;
     }
 
     static protected String methodStaticProtected() {

--- a/tests/java-src/org/jnius2/ChildVisibilityTest.java
+++ b/tests/java-src/org/jnius2/ChildVisibilityTest.java
@@ -1,6 +1,8 @@
-package org.jnius;
+package org.jnius2;
 
 import java.lang.String;
+
+import org.jnius.VisibilityTest;
 
 public class ChildVisibilityTest extends VisibilityTest {
     public String fieldChildPublic = "ChildPublic";

--- a/tests/test_visibility_all.py
+++ b/tests/test_visibility_all.py
@@ -27,10 +27,12 @@ class VisibilityAllTest(unittest.TestCase):
         Test = autoclass('org.jnius.VisibilityTest', include_protected=True, include_private=True)
 
         self.assertTrue(hasattr(Test, 'fieldStaticPublic'))
+        self.assertTrue(hasattr(Test, 'fieldStaticPackageProtected'))
         self.assertTrue(hasattr(Test, 'fieldStaticProtected'))
         self.assertTrue(hasattr(Test, 'fieldStaticPrivate'))
 
         self.assertEqual(Test.fieldStaticPublic, py2_encode("StaticPublic"))
+        self.assertEqual(Test.fieldStaticPackageProtected, py2_encode("StaticPackageProtected"))
         self.assertEqual(Test.fieldStaticProtected, py2_encode("StaticProtected"))
         self.assertEqual(Test.fieldStaticPrivate, py2_encode("StaticPrivate"))
 
@@ -38,18 +40,22 @@ class VisibilityAllTest(unittest.TestCase):
         Test = autoclass('org.jnius.ChildVisibilityTest', include_protected=True, include_private=True)
 
         self.assertTrue(hasattr(Test, 'fieldStaticPublic'))
+        self.assertTrue(hasattr(Test, 'fieldStaticPackageProtected'))
         self.assertTrue(hasattr(Test, 'fieldStaticProtected'))
         self.assertTrue(hasattr(Test, 'fieldStaticPrivate'))
 
         self.assertEqual(Test.fieldStaticPublic, py2_encode("StaticPublic"))
+        self.assertEqual(Test.fieldStaticPackageProtected, py2_encode("StaticPackageProtected"))
         self.assertEqual(Test.fieldStaticProtected, py2_encode("StaticProtected"))
         self.assertEqual(Test.fieldStaticPrivate, py2_encode("StaticPrivate"))
 
         self.assertTrue(hasattr(Test, 'fieldChildStaticPublic'))
+        self.assertTrue(hasattr(Test, 'fieldChildStaticPackageProtected'))
         self.assertTrue(hasattr(Test, 'fieldChildStaticProtected'))
         self.assertTrue(hasattr(Test, 'fieldChildStaticPrivate'))
 
         self.assertEqual(Test.fieldChildStaticPublic, py2_encode("ChildStaticPublic"))
+        self.assertEqual(Test.fieldChildStaticPackageProtected, py2_encode("ChildStaticPackageProtected"))
         self.assertEqual(Test.fieldChildStaticProtected, py2_encode("ChildStaticProtected"))
         self.assertEqual(Test.fieldChildStaticPrivate, py2_encode("ChildStaticPrivate"))
 
@@ -57,10 +63,12 @@ class VisibilityAllTest(unittest.TestCase):
         Test = autoclass('org.jnius.VisibilityTest', include_protected=True, include_private=True)
 
         self.assertTrue(hasattr(Test, 'methodStaticPublic'))
+        self.assertTrue(hasattr(Test, 'methodStaticPackageProtected'))
         self.assertTrue(hasattr(Test, 'methodStaticProtected'))
         self.assertTrue(hasattr(Test, 'methodStaticPrivate'))
 
         self.assertEqual(Test.methodStaticPublic(), py2_encode("StaticPublic"))
+        self.assertEqual(Test.methodStaticPackageProtected(), py2_encode("StaticPackageProtected"))
         self.assertEqual(Test.methodStaticProtected(), py2_encode("StaticProtected"))
         self.assertEqual(Test.methodStaticPrivate(), py2_encode("StaticPrivate"))
 
@@ -68,18 +76,22 @@ class VisibilityAllTest(unittest.TestCase):
         Test = autoclass('org.jnius.ChildVisibilityTest', include_protected=True, include_private=True)
 
         self.assertTrue(hasattr(Test, 'methodStaticPublic'))
+        self.assertTrue(hasattr(Test, 'methodStaticPackageProtected'))
         self.assertTrue(hasattr(Test, 'methodStaticProtected'))
         self.assertTrue(hasattr(Test, 'methodStaticPrivate'))
 
         self.assertEqual(Test.methodStaticPublic(), py2_encode("StaticPublic"))
+        self.assertEqual(Test.methodStaticPackageProtected(), py2_encode("StaticPackageProtected"))
         self.assertEqual(Test.methodStaticProtected(), py2_encode("StaticProtected"))
         self.assertEqual(Test.methodStaticPrivate(), py2_encode("StaticPrivate"))
 
         self.assertTrue(hasattr(Test, 'methodChildStaticPublic'))
+        self.assertTrue(hasattr(Test, 'methodChildStaticPackageProtected'))
         self.assertTrue(hasattr(Test, 'methodChildStaticProtected'))
         self.assertTrue(hasattr(Test, 'methodChildStaticPrivate'))
 
         self.assertEqual(Test.methodChildStaticPublic(), py2_encode("ChildStaticPublic"))
+        self.assertEqual(Test.methodChildStaticPackageProtected(), py2_encode("ChildStaticPackageProtected"))
         self.assertEqual(Test.methodChildStaticProtected(), py2_encode("ChildStaticProtected"))
         self.assertEqual(Test.methodChildStaticPrivate(), py2_encode("ChildStaticPrivate"))
 
@@ -88,10 +100,12 @@ class VisibilityAllTest(unittest.TestCase):
         test = Test()
 
         self.assertTrue(hasattr(test, 'fieldPublic'))
+        self.assertTrue(hasattr(test, 'fieldPackageProtected'))
         self.assertTrue(hasattr(test, 'fieldProtected'))
         self.assertTrue(hasattr(test, 'fieldPrivate'))
 
         self.assertEqual(test.fieldPublic, py2_encode("Public"))
+        self.assertEqual(test.fieldPackageProtected, py2_encode("PackageProtected"))
         self.assertEqual(test.fieldProtected, py2_encode("Protected"))
         self.assertEqual(test.fieldPrivate, py2_encode("Private"))
 
@@ -100,18 +114,22 @@ class VisibilityAllTest(unittest.TestCase):
         test = Test()
 
         self.assertTrue(hasattr(test, 'fieldPublic'))
+        self.assertTrue(hasattr(test, 'fieldPackageProtected'))
         self.assertTrue(hasattr(test, 'fieldProtected'))
         self.assertTrue(hasattr(test, 'fieldPrivate'))
 
         self.assertEqual(test.fieldPublic, py2_encode("Public"))
+        self.assertEqual(test.fieldPackageProtected, py2_encode("PackageProtected"))
         self.assertEqual(test.fieldProtected, py2_encode("Protected"))
         self.assertEqual(test.fieldPrivate, py2_encode("Private"))
 
         self.assertTrue(hasattr(test, 'fieldChildPublic'))
+        self.assertTrue(hasattr(test, 'fieldChildPackageProtected'))
         self.assertTrue(hasattr(test, 'fieldChildProtected'))
         self.assertTrue(hasattr(test, 'fieldChildPrivate'))
 
         self.assertEqual(test.fieldChildPublic, py2_encode("ChildPublic"))
+        self.assertEqual(test.fieldChildPackageProtected, py2_encode("ChildPackageProtected"))
         self.assertEqual(test.fieldChildProtected, py2_encode("ChildProtected"))
         self.assertEqual(test.fieldChildPrivate, py2_encode("ChildPrivate"))
 
@@ -120,22 +138,35 @@ class VisibilityAllTest(unittest.TestCase):
         test = Test()
 
         self.assertTrue(hasattr(test, 'methodPublic'))
+        self.assertTrue(hasattr(test, 'methodPackageProtected'))
         self.assertTrue(hasattr(test, 'methodProtected'))
         self.assertTrue(hasattr(test, 'methodPrivate'))
 
         self.assertEqual(test.methodPublic(), py2_encode("Public"))
+        self.assertEqual(test.methodPackageProtected(), py2_encode("PackageProtected"))
         self.assertEqual(test.methodProtected(), py2_encode("Protected"))
         self.assertEqual(test.methodPrivate(), py2_encode("Private"))
 
     def test_child_methods_all(self):
         Test = autoclass('org.jnius.ChildVisibilityTest', include_protected=True, include_private=True)
         test = Test()
+        self.assertTrue(hasattr(test, 'methodPublic'))
+        self.assertTrue(hasattr(test, 'methodPackageProtected'))
+        self.assertTrue(hasattr(test, 'methodProtected'))
+        self.assertTrue(hasattr(test, 'methodPrivate'))
+
+        self.assertEqual(test.methodPublic(), py2_encode("Public"))
+        self.assertEqual(test.methodPackageProtected(), py2_encode("PackageProtected"))
+        self.assertEqual(test.methodProtected(), py2_encode("Protected"))
+        self.assertEqual(test.methodPrivate(), py2_encode("Private"))
 
         self.assertTrue(hasattr(test, 'methodChildPublic'))
+        self.assertTrue(hasattr(test, 'methodChildPackageProtected'))
         self.assertTrue(hasattr(test, 'methodChildProtected'))
         self.assertTrue(hasattr(test, 'methodChildPrivate'))
 
         self.assertEqual(test.methodChildPublic(), py2_encode("ChildPublic"))
+        self.assertEqual(test.methodChildPackageProtected(), py2_encode("ChildPackageProtected"))
         self.assertEqual(test.methodChildProtected(), py2_encode("ChildProtected"))
         self.assertEqual(test.methodChildPrivate(), py2_encode("ChildPrivate"))
 

--- a/tests/test_visibility_package_protected.py
+++ b/tests/test_visibility_package_protected.py
@@ -21,9 +21,9 @@ def py2_encode(uni):
     return uni
 
 
-class VisibilityPublicOnlyTest(unittest.TestCase):
+class VisibilityPackageProtectedTest(unittest.TestCase):
 
-    def test_static_fields_public_only(self):
+    def test_static_fields_package_protected(self):
         Test = autoclass('org.jnius.VisibilityTest', include_protected=False, include_private=False)
 
         self.assertTrue(hasattr(Test, 'fieldStaticPublic'))
@@ -34,16 +34,15 @@ class VisibilityPublicOnlyTest(unittest.TestCase):
         self.assertEqual(Test.fieldStaticPublic, py2_encode("StaticPublic"))
         self.assertEqual(Test.fieldStaticPackageProtected, py2_encode("StaticPackageProtected"))
 
-    def test_child_static_fields_public_only(self):
-        Test = autoclass('org.jnius.ChildVisibilityTest', include_protected=False, include_private=False)
+    def test_child_static_fields_package_protected(self):
+        Test = autoclass('org.jnius2.ChildVisibilityTest', include_protected=False, include_private=False)
 
         self.assertTrue(hasattr(Test, 'fieldStaticPublic'))
-        self.assertTrue(hasattr(Test, 'fieldStaticPackageProtected'))
+        self.assertFalse(hasattr(Test, 'fieldStaticPackageProtected'))
         self.assertFalse(hasattr(Test, 'fieldStaticProtected'))
         self.assertFalse(hasattr(Test, 'fieldStaticPrivate'))
 
         self.assertEqual(Test.fieldStaticPublic, py2_encode("StaticPublic"))
-        self.assertEqual(Test.fieldStaticPackageProtected, py2_encode("StaticPackageProtected"))
 
         self.assertTrue(hasattr(Test, 'fieldChildStaticPublic'))
         self.assertTrue(hasattr(Test, 'fieldChildStaticPackageProtected'))
@@ -53,7 +52,7 @@ class VisibilityPublicOnlyTest(unittest.TestCase):
         self.assertEqual(Test.fieldChildStaticPublic, py2_encode("ChildStaticPublic"))
         self.assertEqual(Test.fieldChildStaticPackageProtected, py2_encode("ChildStaticPackageProtected"))
 
-    def test_static_methods_public_only(self):
+    def test_static_methods_package_protected(self):
         Test = autoclass('org.jnius.VisibilityTest', include_protected=False, include_private=False)
 
         self.assertTrue(hasattr(Test, 'methodStaticPublic'))
@@ -64,16 +63,15 @@ class VisibilityPublicOnlyTest(unittest.TestCase):
         self.assertEqual(Test.methodStaticPublic(), py2_encode("StaticPublic"))
         self.assertEqual(Test.methodStaticPackageProtected(), py2_encode("StaticPackageProtected"))
 
-    def test_child_static_methods_public_only(self):
-        Test = autoclass('org.jnius.ChildVisibilityTest', include_protected=False, include_private=False)
+    def test_child_static_methods_package_protected(self):
+        Test = autoclass('org.jnius2.ChildVisibilityTest', include_protected=False, include_private=False)
 
         self.assertTrue(hasattr(Test, 'methodStaticPublic'))
-        self.assertTrue(hasattr(Test, 'methodStaticPackageProtected'))
+        self.assertFalse(hasattr(Test, 'methodStaticPackageProtected'))
         self.assertFalse(hasattr(Test, 'methodStaticProtected'))
         self.assertFalse(hasattr(Test, 'methodStaticPrivate'))
 
         self.assertEqual(Test.methodStaticPublic(), py2_encode("StaticPublic"))
-        self.assertEqual(Test.methodStaticPackageProtected(), py2_encode("StaticPackageProtected"))
 
         self.assertTrue(hasattr(Test, 'methodChildStaticPublic'))
         self.assertTrue(hasattr(Test, 'methodChildStaticPackageProtected'))
@@ -83,7 +81,7 @@ class VisibilityPublicOnlyTest(unittest.TestCase):
         self.assertEqual(Test.methodChildStaticPublic(), py2_encode("ChildStaticPublic"))
         self.assertEqual(Test.methodChildStaticPackageProtected(), py2_encode("ChildStaticPackageProtected"))
 
-    def test_fields_public_only(self):
+    def test_fields_package_protected(self):
 
         Test = autoclass('org.jnius.VisibilityTest', include_protected=False, include_private=False)
         test = Test()
@@ -96,18 +94,17 @@ class VisibilityPublicOnlyTest(unittest.TestCase):
         self.assertEqual(test.fieldPublic, py2_encode("Public"))
         self.assertEqual(test.fieldPackageProtected, py2_encode("PackageProtected"))
 
-    def test_child_fields_public_only(self):
+    def test_child_fields_package_protected(self):
 
-        Test = autoclass('org.jnius.ChildVisibilityTest', include_protected=False, include_private=False)
+        Test = autoclass('org.jnius2.ChildVisibilityTest', include_protected=False, include_private=False)
         test = Test()
 
         self.assertTrue(hasattr(test, 'fieldPublic'))
-        self.assertTrue(hasattr(test, 'fieldPackageProtected'))
+        self.assertFalse(hasattr(test, 'fieldPackageProtected'))
         self.assertFalse(hasattr(test, 'fieldProtected'))
         self.assertFalse(hasattr(test, 'fieldPrivate'))
 
         self.assertEqual(test.fieldPublic, py2_encode("Public"))
-        self.assertEqual(test.fieldPackageProtected, py2_encode("PackageProtected"))
 
         self.assertTrue(hasattr(test, 'fieldChildPublic'))
         self.assertTrue(hasattr(test, 'fieldChildPackageProtected'))
@@ -117,7 +114,7 @@ class VisibilityPublicOnlyTest(unittest.TestCase):
         self.assertEqual(test.fieldChildPublic, py2_encode("ChildPublic"))
         self.assertEqual(test.fieldChildPackageProtected, py2_encode("ChildPackageProtected"))
 
-    def test_methods_public_only(self):
+    def test_methods_package_protected(self):
 
         Test = autoclass('org.jnius.VisibilityTest', include_protected=False, include_private=False)
         test = Test()
@@ -130,18 +127,17 @@ class VisibilityPublicOnlyTest(unittest.TestCase):
         self.assertEqual(test.methodPublic(), py2_encode("Public"))
         self.assertEqual(test.methodPackageProtected(), py2_encode("PackageProtected"))
 
-    def test_child_methods_public_only(self):
+    def test_child_methods_package_protected(self):
 
-        Test = autoclass('org.jnius.ChildVisibilityTest', include_protected=False, include_private=False)
+        Test = autoclass('org.jnius2.ChildVisibilityTest', include_protected=False, include_private=False)
         test = Test()
 
         self.assertTrue(hasattr(test, 'methodPublic'))
-        self.assertTrue(hasattr(test, 'methodPackageProtected'))
+        self.assertFalse(hasattr(test, 'methodPackageProtected'))
         self.assertFalse(hasattr(test, 'methodProtected'))
         self.assertFalse(hasattr(test, 'methodPrivate'))
 
         self.assertEqual(test.methodPublic(), py2_encode("Public"))
-        self.assertEqual(test.methodPackageProtected(), py2_encode("PackageProtected"))
 
         self.assertTrue(hasattr(test, 'methodChildPublic'))
         self.assertTrue(hasattr(test, 'methodChildPackageProtected'))
@@ -152,7 +148,7 @@ class VisibilityPublicOnlyTest(unittest.TestCase):
         self.assertEqual(test.methodChildPackageProtected(), py2_encode("ChildPackageProtected"))
 
     def test_static_multi_methods(self):
-        Test = autoclass('org.jnius.ChildVisibilityTest', include_protected=False, include_private=False)
+        Test = autoclass('org.jnius2.ChildVisibilityTest', include_protected=False, include_private=False)
 
         self.assertTrue(hasattr(Test, 'methodStaticMultiArgs'))
         self.assertTrue(isinstance(Test.methodStaticMultiArgs, JavaStaticMethod))
@@ -164,7 +160,7 @@ class VisibilityPublicOnlyTest(unittest.TestCase):
             Test.methodStaticMultiArgs(True, False, True)
 
     def test_multi_methods(self):
-        Test = autoclass('org.jnius.ChildVisibilityTest', include_protected=False, include_private=False)
+        Test = autoclass('org.jnius2.ChildVisibilityTest', include_protected=False, include_private=False)
         test = Test()
 
         self.assertTrue(hasattr(test, 'methodMultiArgs'))

--- a/tests/test_visibility_package_protected.py
+++ b/tests/test_visibility_package_protected.py
@@ -22,152 +22,94 @@ def py2_encode(uni):
 
 
 class VisibilityPackageProtectedTest(unittest.TestCase):
+    """This unittest verifies the correct visibility of package protected methods and fields.
 
-    def test_static_fields_package_protected(self):
-        Test = autoclass('org.jnius.VisibilityTest', include_protected=False, include_private=False)
-
-        self.assertTrue(hasattr(Test, 'fieldStaticPublic'))
-        self.assertTrue(hasattr(Test, 'fieldStaticPackageProtected'))
-        self.assertFalse(hasattr(Test, 'fieldStaticProtected'))
-        self.assertFalse(hasattr(Test, 'fieldStaticPrivate'))
-
-        self.assertEqual(Test.fieldStaticPublic, py2_encode("StaticPublic"))
-        self.assertEqual(Test.fieldStaticPackageProtected, py2_encode("StaticPackageProtected"))
+    Observe that org.jnius2.ChildVisibilityTest is not in the same package as
+    it's parent class. If `include_protected` is True and `include_private`
+    is False, only the package protected methods and fields in the child class
+    should be visible.
+    """
 
     def test_child_static_fields_package_protected(self):
-        Test = autoclass('org.jnius2.ChildVisibilityTest', include_protected=False, include_private=False)
+        Test = autoclass('org.jnius2.ChildVisibilityTest', include_protected=True, include_private=False)
 
         self.assertTrue(hasattr(Test, 'fieldStaticPublic'))
         self.assertFalse(hasattr(Test, 'fieldStaticPackageProtected'))
-        self.assertFalse(hasattr(Test, 'fieldStaticProtected'))
+        self.assertTrue(hasattr(Test, 'fieldStaticProtected'))
         self.assertFalse(hasattr(Test, 'fieldStaticPrivate'))
 
         self.assertEqual(Test.fieldStaticPublic, py2_encode("StaticPublic"))
+        self.assertEqual(Test.fieldStaticProtected, py2_encode("StaticProtected"))
 
         self.assertTrue(hasattr(Test, 'fieldChildStaticPublic'))
         self.assertTrue(hasattr(Test, 'fieldChildStaticPackageProtected'))
-        self.assertFalse(hasattr(Test, 'fieldChildStaticProtected'))
+        self.assertTrue(hasattr(Test, 'fieldChildStaticProtected'))
         self.assertFalse(hasattr(Test, 'fieldChildStaticPrivate'))
 
         self.assertEqual(Test.fieldChildStaticPublic, py2_encode("ChildStaticPublic"))
         self.assertEqual(Test.fieldChildStaticPackageProtected, py2_encode("ChildStaticPackageProtected"))
-
-    def test_static_methods_package_protected(self):
-        Test = autoclass('org.jnius.VisibilityTest', include_protected=False, include_private=False)
-
-        self.assertTrue(hasattr(Test, 'methodStaticPublic'))
-        self.assertTrue(hasattr(Test, 'methodStaticPackageProtected'))
-        self.assertFalse(hasattr(Test, 'methodStaticProtected'))
-        self.assertFalse(hasattr(Test, 'methodStaticPrivate'))
-
-        self.assertEqual(Test.methodStaticPublic(), py2_encode("StaticPublic"))
-        self.assertEqual(Test.methodStaticPackageProtected(), py2_encode("StaticPackageProtected"))
+        self.assertEqual(Test.fieldChildStaticProtected, py2_encode("ChildStaticProtected"))
 
     def test_child_static_methods_package_protected(self):
-        Test = autoclass('org.jnius2.ChildVisibilityTest', include_protected=False, include_private=False)
+        Test = autoclass('org.jnius2.ChildVisibilityTest', include_protected=True, include_private=False)
 
         self.assertTrue(hasattr(Test, 'methodStaticPublic'))
         self.assertFalse(hasattr(Test, 'methodStaticPackageProtected'))
-        self.assertFalse(hasattr(Test, 'methodStaticProtected'))
+        self.assertTrue(hasattr(Test, 'methodStaticProtected'))
         self.assertFalse(hasattr(Test, 'methodStaticPrivate'))
 
         self.assertEqual(Test.methodStaticPublic(), py2_encode("StaticPublic"))
+        self.assertEqual(Test.methodStaticProtected(), py2_encode("StaticProtected"))
 
         self.assertTrue(hasattr(Test, 'methodChildStaticPublic'))
         self.assertTrue(hasattr(Test, 'methodChildStaticPackageProtected'))
-        self.assertFalse(hasattr(Test, 'methodChildStaticProtected'))
+        self.assertTrue(hasattr(Test, 'methodChildStaticProtected'))
         self.assertFalse(hasattr(Test, 'methodChildStaticPrivate'))
 
         self.assertEqual(Test.methodChildStaticPublic(), py2_encode("ChildStaticPublic"))
         self.assertEqual(Test.methodChildStaticPackageProtected(), py2_encode("ChildStaticPackageProtected"))
-
-    def test_fields_package_protected(self):
-
-        Test = autoclass('org.jnius.VisibilityTest', include_protected=False, include_private=False)
-        test = Test()
-
-        self.assertTrue(hasattr(test, 'fieldPublic'))
-        self.assertTrue(hasattr(test, 'fieldPackageProtected'))
-        self.assertFalse(hasattr(test, 'fieldProtected'))
-        self.assertFalse(hasattr(test, 'fieldPrivate'))
-
-        self.assertEqual(test.fieldPublic, py2_encode("Public"))
-        self.assertEqual(test.fieldPackageProtected, py2_encode("PackageProtected"))
+        self.assertEqual(Test.methodChildStaticProtected(), py2_encode("ChildStaticProtected"))
 
     def test_child_fields_package_protected(self):
 
-        Test = autoclass('org.jnius2.ChildVisibilityTest', include_protected=False, include_private=False)
+        Test = autoclass('org.jnius2.ChildVisibilityTest', include_protected=True, include_private=False)
         test = Test()
 
         self.assertTrue(hasattr(test, 'fieldPublic'))
         self.assertFalse(hasattr(test, 'fieldPackageProtected'))
-        self.assertFalse(hasattr(test, 'fieldProtected'))
+        self.assertTrue(hasattr(test, 'fieldProtected'))
         self.assertFalse(hasattr(test, 'fieldPrivate'))
 
         self.assertEqual(test.fieldPublic, py2_encode("Public"))
+        self.assertEqual(test.fieldProtected, py2_encode("Protected"))
 
         self.assertTrue(hasattr(test, 'fieldChildPublic'))
         self.assertTrue(hasattr(test, 'fieldChildPackageProtected'))
-        self.assertFalse(hasattr(test, 'fieldChildProtected'))
+        self.assertTrue(hasattr(test, 'fieldChildProtected'))
         self.assertFalse(hasattr(test, 'fieldChildPrivate'))
 
         self.assertEqual(test.fieldChildPublic, py2_encode("ChildPublic"))
         self.assertEqual(test.fieldChildPackageProtected, py2_encode("ChildPackageProtected"))
-
-    def test_methods_package_protected(self):
-
-        Test = autoclass('org.jnius.VisibilityTest', include_protected=False, include_private=False)
-        test = Test()
-
-        self.assertTrue(hasattr(test, 'methodPublic'))
-        self.assertTrue(hasattr(test, 'methodPackageProtected'))
-        self.assertFalse(hasattr(test, 'methodProtected'))
-        self.assertFalse(hasattr(test, 'methodPrivate'))
-
-        self.assertEqual(test.methodPublic(), py2_encode("Public"))
-        self.assertEqual(test.methodPackageProtected(), py2_encode("PackageProtected"))
+        self.assertEqual(test.fieldChildProtected, py2_encode("ChildProtected"))
 
     def test_child_methods_package_protected(self):
 
-        Test = autoclass('org.jnius2.ChildVisibilityTest', include_protected=False, include_private=False)
+        Test = autoclass('org.jnius2.ChildVisibilityTest', include_protected=True, include_private=False)
         test = Test()
 
         self.assertTrue(hasattr(test, 'methodPublic'))
         self.assertFalse(hasattr(test, 'methodPackageProtected'))
-        self.assertFalse(hasattr(test, 'methodProtected'))
+        self.assertTrue(hasattr(test, 'methodProtected'))
         self.assertFalse(hasattr(test, 'methodPrivate'))
 
         self.assertEqual(test.methodPublic(), py2_encode("Public"))
+        self.assertEqual(test.methodProtected(), py2_encode("Protected"))
 
         self.assertTrue(hasattr(test, 'methodChildPublic'))
         self.assertTrue(hasattr(test, 'methodChildPackageProtected'))
-        self.assertFalse(hasattr(test, 'methodChildProtected'))
+        self.assertTrue(hasattr(test, 'methodChildProtected'))
         self.assertFalse(hasattr(test, 'methodChildPrivate'))
 
         self.assertEqual(test.methodChildPublic(), py2_encode("ChildPublic"))
         self.assertEqual(test.methodChildPackageProtected(), py2_encode("ChildPackageProtected"))
-
-    def test_static_multi_methods(self):
-        Test = autoclass('org.jnius2.ChildVisibilityTest', include_protected=False, include_private=False)
-
-        self.assertTrue(hasattr(Test, 'methodStaticMultiArgs'))
-        self.assertTrue(isinstance(Test.methodStaticMultiArgs, JavaStaticMethod))
-
-        self.assertTrue(Test.methodStaticMultiArgs(True))
-        with self.assertRaises(JavaException):
-            Test.methodStaticMultiArgs(True, False)
-        with self.assertRaises(JavaException):
-            Test.methodStaticMultiArgs(True, False, True)
-
-    def test_multi_methods(self):
-        Test = autoclass('org.jnius2.ChildVisibilityTest', include_protected=False, include_private=False)
-        test = Test()
-
-        self.assertTrue(hasattr(test, 'methodMultiArgs'))
-        self.assertTrue(isinstance(Test.methodMultiArgs, JavaMethod))
-
-        self.assertTrue(test.methodMultiArgs(True))
-        with self.assertRaises(JavaException):
-            test.methodMultiArgs(True, False)
-        with self.assertRaises(JavaException):
-           test.methodMultiArgs(True, False, True)
+        self.assertEqual(test.methodChildProtected(), py2_encode("ChildProtected"))

--- a/tests/test_visibility_public_only.py
+++ b/tests/test_visibility_public_only.py
@@ -27,61 +27,55 @@ class VisibilityPublicOnlyTest(unittest.TestCase):
         Test = autoclass('org.jnius.VisibilityTest', include_protected=False, include_private=False)
 
         self.assertTrue(hasattr(Test, 'fieldStaticPublic'))
-        self.assertTrue(hasattr(Test, 'fieldStaticPackageProtected'))
+        self.assertFalse(hasattr(Test, 'fieldStaticPackageProtected'))
         self.assertFalse(hasattr(Test, 'fieldStaticProtected'))
         self.assertFalse(hasattr(Test, 'fieldStaticPrivate'))
 
         self.assertEqual(Test.fieldStaticPublic, py2_encode("StaticPublic"))
-        self.assertEqual(Test.fieldStaticPackageProtected, py2_encode("StaticPackageProtected"))
 
     def test_child_static_fields_public_only(self):
         Test = autoclass('org.jnius.ChildVisibilityTest', include_protected=False, include_private=False)
 
         self.assertTrue(hasattr(Test, 'fieldStaticPublic'))
-        self.assertTrue(hasattr(Test, 'fieldStaticPackageProtected'))
+        self.assertFalse(hasattr(Test, 'fieldStaticPackageProtected'))
         self.assertFalse(hasattr(Test, 'fieldStaticProtected'))
         self.assertFalse(hasattr(Test, 'fieldStaticPrivate'))
 
         self.assertEqual(Test.fieldStaticPublic, py2_encode("StaticPublic"))
-        self.assertEqual(Test.fieldStaticPackageProtected, py2_encode("StaticPackageProtected"))
 
         self.assertTrue(hasattr(Test, 'fieldChildStaticPublic'))
-        self.assertTrue(hasattr(Test, 'fieldChildStaticPackageProtected'))
+        self.assertFalse(hasattr(Test, 'fieldChildStaticPackageProtected'))
         self.assertFalse(hasattr(Test, 'fieldChildStaticProtected'))
         self.assertFalse(hasattr(Test, 'fieldChildStaticPrivate'))
 
         self.assertEqual(Test.fieldChildStaticPublic, py2_encode("ChildStaticPublic"))
-        self.assertEqual(Test.fieldChildStaticPackageProtected, py2_encode("ChildStaticPackageProtected"))
 
     def test_static_methods_public_only(self):
         Test = autoclass('org.jnius.VisibilityTest', include_protected=False, include_private=False)
 
         self.assertTrue(hasattr(Test, 'methodStaticPublic'))
-        self.assertTrue(hasattr(Test, 'methodStaticPackageProtected'))
+        self.assertFalse(hasattr(Test, 'methodStaticPackageProtected'))
         self.assertFalse(hasattr(Test, 'methodStaticProtected'))
         self.assertFalse(hasattr(Test, 'methodStaticPrivate'))
 
         self.assertEqual(Test.methodStaticPublic(), py2_encode("StaticPublic"))
-        self.assertEqual(Test.methodStaticPackageProtected(), py2_encode("StaticPackageProtected"))
 
     def test_child_static_methods_public_only(self):
         Test = autoclass('org.jnius.ChildVisibilityTest', include_protected=False, include_private=False)
 
         self.assertTrue(hasattr(Test, 'methodStaticPublic'))
-        self.assertTrue(hasattr(Test, 'methodStaticPackageProtected'))
+        self.assertFalse(hasattr(Test, 'methodStaticPackageProtected'))
         self.assertFalse(hasattr(Test, 'methodStaticProtected'))
         self.assertFalse(hasattr(Test, 'methodStaticPrivate'))
 
         self.assertEqual(Test.methodStaticPublic(), py2_encode("StaticPublic"))
-        self.assertEqual(Test.methodStaticPackageProtected(), py2_encode("StaticPackageProtected"))
 
         self.assertTrue(hasattr(Test, 'methodChildStaticPublic'))
-        self.assertTrue(hasattr(Test, 'methodChildStaticPackageProtected'))
+        self.assertFalse(hasattr(Test, 'methodChildStaticPackageProtected'))
         self.assertFalse(hasattr(Test, 'methodChildStaticProtected'))
         self.assertFalse(hasattr(Test, 'methodChildStaticPrivate'))
 
         self.assertEqual(Test.methodChildStaticPublic(), py2_encode("ChildStaticPublic"))
-        self.assertEqual(Test.methodChildStaticPackageProtected(), py2_encode("ChildStaticPackageProtected"))
 
     def test_fields_public_only(self):
 
@@ -89,12 +83,11 @@ class VisibilityPublicOnlyTest(unittest.TestCase):
         test = Test()
 
         self.assertTrue(hasattr(test, 'fieldPublic'))
-        self.assertTrue(hasattr(test, 'fieldPackageProtected'))
+        self.assertFalse(hasattr(test, 'fieldPackageProtected'))
         self.assertFalse(hasattr(test, 'fieldProtected'))
         self.assertFalse(hasattr(test, 'fieldPrivate'))
 
         self.assertEqual(test.fieldPublic, py2_encode("Public"))
-        self.assertEqual(test.fieldPackageProtected, py2_encode("PackageProtected"))
 
     def test_child_fields_public_only(self):
 
@@ -102,20 +95,18 @@ class VisibilityPublicOnlyTest(unittest.TestCase):
         test = Test()
 
         self.assertTrue(hasattr(test, 'fieldPublic'))
-        self.assertTrue(hasattr(test, 'fieldPackageProtected'))
+        self.assertFalse(hasattr(test, 'fieldPackageProtected'))
         self.assertFalse(hasattr(test, 'fieldProtected'))
         self.assertFalse(hasattr(test, 'fieldPrivate'))
 
         self.assertEqual(test.fieldPublic, py2_encode("Public"))
-        self.assertEqual(test.fieldPackageProtected, py2_encode("PackageProtected"))
 
         self.assertTrue(hasattr(test, 'fieldChildPublic'))
-        self.assertTrue(hasattr(test, 'fieldChildPackageProtected'))
+        self.assertFalse(hasattr(test, 'fieldChildPackageProtected'))
         self.assertFalse(hasattr(test, 'fieldChildProtected'))
         self.assertFalse(hasattr(test, 'fieldChildPrivate'))
 
         self.assertEqual(test.fieldChildPublic, py2_encode("ChildPublic"))
-        self.assertEqual(test.fieldChildPackageProtected, py2_encode("ChildPackageProtected"))
 
     def test_methods_public_only(self):
 
@@ -123,12 +114,11 @@ class VisibilityPublicOnlyTest(unittest.TestCase):
         test = Test()
 
         self.assertTrue(hasattr(test, 'methodPublic'))
-        self.assertTrue(hasattr(test, 'methodPackageProtected'))
+        self.assertFalse(hasattr(test, 'methodPackageProtected'))
         self.assertFalse(hasattr(test, 'methodProtected'))
         self.assertFalse(hasattr(test, 'methodPrivate'))
 
         self.assertEqual(test.methodPublic(), py2_encode("Public"))
-        self.assertEqual(test.methodPackageProtected(), py2_encode("PackageProtected"))
 
     def test_child_methods_public_only(self):
 
@@ -136,20 +126,18 @@ class VisibilityPublicOnlyTest(unittest.TestCase):
         test = Test()
 
         self.assertTrue(hasattr(test, 'methodPublic'))
-        self.assertTrue(hasattr(test, 'methodPackageProtected'))
+        self.assertFalse(hasattr(test, 'methodPackageProtected'))
         self.assertFalse(hasattr(test, 'methodProtected'))
         self.assertFalse(hasattr(test, 'methodPrivate'))
 
         self.assertEqual(test.methodPublic(), py2_encode("Public"))
-        self.assertEqual(test.methodPackageProtected(), py2_encode("PackageProtected"))
 
         self.assertTrue(hasattr(test, 'methodChildPublic'))
-        self.assertTrue(hasattr(test, 'methodChildPackageProtected'))
+        self.assertFalse(hasattr(test, 'methodChildPackageProtected'))
         self.assertFalse(hasattr(test, 'methodChildProtected'))
         self.assertFalse(hasattr(test, 'methodChildPrivate'))
 
         self.assertEqual(test.methodChildPublic(), py2_encode("ChildPublic"))
-        self.assertEqual(test.methodChildPackageProtected(), py2_encode("ChildPackageProtected"))
 
     def test_static_multi_methods(self):
         Test = autoclass('org.jnius.ChildVisibilityTest', include_protected=False, include_private=False)

--- a/tests/test_visibility_public_protected.py
+++ b/tests/test_visibility_public_protected.py
@@ -27,54 +27,66 @@ class VisibilityPublicProtectedTest(unittest.TestCase):
         Test = autoclass('org.jnius.VisibilityTest', include_protected=True, include_private=False)
 
         self.assertTrue(hasattr(Test, 'fieldStaticPublic'))
+        self.assertTrue(hasattr(Test, 'fieldStaticPackageProtected'))
         self.assertTrue(hasattr(Test, 'fieldStaticProtected'))
         self.assertFalse(hasattr(Test, 'fieldStaticPrivate'))
 
         self.assertEqual(Test.fieldStaticPublic, py2_encode("StaticPublic"))
+        self.assertEqual(Test.fieldStaticPackageProtected, py2_encode("StaticPackageProtected"))
         self.assertEqual(Test.fieldStaticProtected, py2_encode("StaticProtected"))
 
     def test_child_static_fields_public_protected(self):
         Test = autoclass('org.jnius.ChildVisibilityTest', include_protected=True, include_private=False)
 
         self.assertTrue(hasattr(Test, 'fieldStaticPublic'))
+        self.assertTrue(hasattr(Test, 'fieldStaticPackageProtected'))
         self.assertTrue(hasattr(Test, 'fieldStaticProtected'))
         self.assertFalse(hasattr(Test, 'fieldStaticPrivate'))
 
         self.assertEqual(Test.fieldStaticPublic, py2_encode("StaticPublic"))
+        self.assertEqual(Test.fieldStaticPackageProtected, py2_encode("StaticPackageProtected"))
         self.assertEqual(Test.fieldStaticProtected, py2_encode("StaticProtected"))
 
         self.assertTrue(hasattr(Test, 'fieldChildStaticPublic'))
+        self.assertTrue(hasattr(Test, 'fieldChildStaticPackageProtected'))
         self.assertTrue(hasattr(Test, 'fieldChildStaticProtected'))
         self.assertFalse(hasattr(Test, 'fieldChildStaticPrivate'))
 
         self.assertEqual(Test.fieldChildStaticPublic, py2_encode("ChildStaticPublic"))
+        self.assertEqual(Test.fieldChildStaticPackageProtected, py2_encode("ChildStaticPackageProtected"))
         self.assertEqual(Test.fieldChildStaticProtected, py2_encode("ChildStaticProtected"))
 
     def test_static_methods_public_protected(self):
         Test = autoclass('org.jnius.VisibilityTest', include_protected=True, include_private=False)
 
         self.assertTrue(hasattr(Test, 'methodStaticPublic'))
+        self.assertTrue(hasattr(Test, 'methodStaticPackageProtected'))
         self.assertTrue(hasattr(Test, 'methodStaticProtected'))
         self.assertFalse(hasattr(Test, 'methodStaticPrivate'))
 
         self.assertEqual(Test.methodStaticPublic(), py2_encode("StaticPublic"))
+        self.assertEqual(Test.methodStaticPackageProtected(), py2_encode("StaticPackageProtected"))
         self.assertEqual(Test.methodStaticProtected(), py2_encode("StaticProtected"))
 
     def test_child_static_methods_public_protected(self):
         Test = autoclass('org.jnius.ChildVisibilityTest', include_protected=True, include_private=False)
 
         self.assertTrue(hasattr(Test, 'methodStaticPublic'))
+        self.assertTrue(hasattr(Test, 'methodStaticPackageProtected'))
         self.assertTrue(hasattr(Test, 'methodStaticProtected'))
         self.assertFalse(hasattr(Test, 'methodStaticPrivate'))
 
         self.assertEqual(Test.methodStaticPublic(), py2_encode("StaticPublic"))
+        self.assertEqual(Test.methodStaticPackageProtected(), py2_encode("StaticPackageProtected"))
         self.assertEqual(Test.methodStaticProtected(), py2_encode("StaticProtected"))
 
         self.assertTrue(hasattr(Test, 'methodChildStaticPublic'))
+        self.assertTrue(hasattr(Test, 'methodChildStaticPackageProtected'))
         self.assertTrue(hasattr(Test, 'methodChildStaticProtected'))
         self.assertFalse(hasattr(Test, 'methodChildStaticPrivate'))
 
         self.assertEqual(Test.methodChildStaticPublic(), py2_encode("ChildStaticPublic"))
+        self.assertEqual(Test.methodChildStaticPackageProtected(), py2_encode("ChildStaticPackageProtected"))
         self.assertEqual(Test.methodChildStaticProtected(), py2_encode("ChildStaticProtected"))
 
     def test_fields_public_protected(self):
@@ -83,10 +95,12 @@ class VisibilityPublicProtectedTest(unittest.TestCase):
         test = Test()
 
         self.assertTrue(hasattr(test, 'fieldPublic'))
+        self.assertTrue(hasattr(test, 'fieldPackageProtected'))
         self.assertTrue(hasattr(test, 'fieldProtected'))
         self.assertFalse(hasattr(test, 'fieldPrivate'))
 
         self.assertEqual(test.fieldPublic, py2_encode("Public"))
+        self.assertEqual(test.fieldPackageProtected, py2_encode("PackageProtected"))
         self.assertEqual(test.fieldProtected, py2_encode("Protected"))
 
     def test_child_fields_public_protected(self):
@@ -95,17 +109,21 @@ class VisibilityPublicProtectedTest(unittest.TestCase):
         test = Test()
 
         self.assertTrue(hasattr(test, 'fieldPublic'))
+        self.assertTrue(hasattr(test, 'fieldPackageProtected'))
         self.assertTrue(hasattr(test, 'fieldProtected'))
         self.assertFalse(hasattr(test, 'fieldPrivate'))
 
         self.assertEqual(test.fieldPublic, py2_encode("Public"))
+        self.assertEqual(test.fieldPackageProtected, py2_encode("PackageProtected"))
         self.assertEqual(test.fieldProtected, py2_encode("Protected"))
 
         self.assertTrue(hasattr(test, 'fieldChildPublic'))
+        self.assertTrue(hasattr(test, 'fieldChildPackageProtected'))
         self.assertTrue(hasattr(test, 'fieldChildProtected'))
         self.assertFalse(hasattr(test, 'fieldChildPrivate'))
 
         self.assertEqual(test.fieldChildPublic, py2_encode("ChildPublic"))
+        self.assertEqual(test.fieldChildPackageProtected, py2_encode("ChildPackageProtected"))
         self.assertEqual(test.fieldChildProtected, py2_encode("ChildProtected"))
 
     def test_methods_public_protected(self):
@@ -114,10 +132,12 @@ class VisibilityPublicProtectedTest(unittest.TestCase):
         test = Test()
 
         self.assertTrue(hasattr(test, 'methodPublic'))
+        self.assertTrue(hasattr(test, 'methodPackageProtected'))
         self.assertTrue(hasattr(test, 'methodProtected'))
         self.assertFalse(hasattr(test, 'methodPrivate'))
 
         self.assertEqual(test.methodPublic(), py2_encode("Public"))
+        self.assertEqual(test.methodPackageProtected(), py2_encode("PackageProtected"))
         self.assertEqual(test.methodProtected(), py2_encode("Protected"))
 
     def test_child_methods_public_protected(self):
@@ -125,11 +145,22 @@ class VisibilityPublicProtectedTest(unittest.TestCase):
         Test = autoclass('org.jnius.ChildVisibilityTest', include_protected=True, include_private=False)
         test = Test()
 
+        self.assertTrue(hasattr(test, 'methodPublic'))
+        self.assertTrue(hasattr(test, 'methodPackageProtected'))
+        self.assertTrue(hasattr(test, 'methodProtected'))
+        self.assertFalse(hasattr(test, 'methodPrivate'))
+
+        self.assertEqual(test.methodPublic(), py2_encode("Public"))
+        self.assertEqual(test.methodPackageProtected(), py2_encode("PackageProtected"))
+        self.assertEqual(test.methodProtected(), py2_encode("Protected"))
+
         self.assertTrue(hasattr(test, 'methodChildPublic'))
+        self.assertTrue(hasattr(test, 'methodChildPackageProtected'))
         self.assertTrue(hasattr(test, 'methodChildProtected'))
         self.assertFalse(hasattr(test, 'methodChildPrivate'))
 
         self.assertEqual(test.methodChildPublic(), py2_encode("ChildPublic"))
+        self.assertEqual(test.methodChildPackageProtected(), py2_encode("ChildPackageProtected"))
         self.assertEqual(test.methodChildProtected(), py2_encode("ChildProtected"))
 
     def test_static_multi_methods(self):


### PR DESCRIPTION
In addition to public, protected, and private visibility, methods and fields can be "package protected".

https://docs.oracle.com/javase/tutorial/java/javaOO/accesscontrol.html

Package protected is the visibility setting when none of public, protected, and private are used (and therefore do not have any of those modifiers). The end result is the visibility depends on if the code is in the same package as the class package.

Rather than make a new `autoclass` parameter called `include_package_protected`, I made it look at the package names as it goes up the class hierarchy and follow `include_protected` if the package name is not the same as the starting package name. @tshirtman @cmacdonald I believe this is the better choice but am not 100% sure and want to hear what you have to say.

This PR also adds some unit test assert statements that should have been added in #500.
