### PR TITLE
expose the class's class attribute

### DIFF
--- a/jnius/reflect.py
+++ b/jnius/reflect.py
@@ -230,6 +230,8 @@ def autoclass(clsname, include_protected=True, include_private=True):
         raise Exception('Java class {0} not found'.format(c))
         return None
 
+    classDict['_class'] = c
+
     constructors = []
     for constructor in c.getConstructors():
         sig = '({0})V'.format(

--- a/tests/test_reflect.py
+++ b/tests/test_reflect.py
@@ -38,6 +38,15 @@ class ReflectTest(unittest.TestCase):
         self.assertEqual(d["java.lang.Object"], maxLevel)
         self.assertEqual(d["java.util.ArrayList"], 0)
 
+    def test_class(self):
+        lstClz = autoclass("java.util.List")
+        self.assertTrue("_class" in dir(lstClz))
+        self.assertEqual("java.util.List", lstClz._class.getName())
+        alstClz = autoclass("java.util.ArrayList")
+        self.assertTrue("_class" in dir(alstClz))
+        self.assertEqual("java.util.ArrayList", alstClz._class.getName())
+        self.assertEqual("java.util.ArrayList", alstClz().getClass().getName())
+
     def test_stack(self):
         Stack = autoclass('java.util.Stack')
         stack = Stack()


### PR DESCRIPTION
In Java, I can use `String.class` to get the String class' Class object. 
In Jnius, its not exposed. This fixes this.

Note that as `class` is a reserved keyword in Python, the attribute is `._class`, so the python equivalent is `autoclass("java.lang.String")._class`.

Includes a unit test.