### PR TITLE
remove <char> casts to allow for than 256 characters

### DIFF
--- a/jnius/jnius_conversion.pxi
+++ b/jnius/jnius_conversion.pxi
@@ -286,7 +286,7 @@ cdef convert_jarray_to_python(JNIEnv *j_env, definition, jobject j_object):
         j_chars = j_env[0].GetCharArrayElements(
                 j_env, j_object, &iscopy)
 
-        if sys.version_info < (3, 0):
+        if PY_MAJOR_VERSION < 3:
             ret = [chr(<char>j_chars[i]) for i in range(array_size)]
         else:
             ret = [chr(j_chars[i]) for i in range(array_size)]

--- a/jnius/jnius_conversion.pxi
+++ b/jnius/jnius_conversion.pxi
@@ -285,7 +285,11 @@ cdef convert_jarray_to_python(JNIEnv *j_env, definition, jobject j_object):
     elif r == 'C':
         j_chars = j_env[0].GetCharArrayElements(
                 j_env, j_object, &iscopy)
-        ret = [chr(<char>j_chars[i]) for i in range(array_size)]
+
+        if sys.version_info < (3, 0):
+            ret = [chr(<char>j_chars[i]) for i in range(array_size)]
+        else:
+            ret = [chr(j_chars[i]) for i in range(array_size)]
         j_env[0].ReleaseCharArrayElements(
                 j_env, j_object, j_chars, 0)
 

--- a/jnius/jnius_export_class.pxi
+++ b/jnius/jnius_export_class.pxi
@@ -1,6 +1,6 @@
 from cpython cimport PyObject
+from cpython.version cimport PY_MAJOR_VERSION
 from warnings import warn
-import sys
 
 
 class JavaException(Exception):
@@ -570,7 +570,7 @@ cdef class JavaField(object):
         elif r == 'C':
             j_char = j_env[0].GetCharField(
                     j_env, j_self, self.j_field)
-            if sys.version_info < (3, 0):
+            if PY_MAJOR_VERSION < 3:
                 ret = chr(<char>j_char)
             else:
                 ret = chr(j_char)
@@ -697,7 +697,7 @@ cdef class JavaField(object):
         elif r == 'C':
             j_char = j_env[0].GetStaticCharField(
                     j_env, self.j_cls, self.j_field)
-            if sys.version_info < (3, 0):
+            if PY_MAJOR_VERSION < 3:
                 ret = chr(<char>j_char)
             else:
                 ret = chr(j_char)
@@ -901,7 +901,7 @@ cdef class JavaMethod(object):
             with nogil:
                 j_char = j_env[0].CallCharMethodA(
                         j_env, j_self, self.j_method, j_args)
-            if sys.version_info < (3, 0):
+            if PY_MAJOR_VERSION < 3:
                 ret = chr(<char>j_char)
             else:
                 ret = chr(j_char)
@@ -992,7 +992,7 @@ cdef class JavaMethod(object):
             with nogil:
                 j_char = j_env[0].CallStaticCharMethodA(
                         j_env, self.j_cls, self.j_method, j_args)
-            if sys.version_info < (3, 0):
+            if PY_MAJOR_VERSION < 3:
                 ret = chr(<char>j_char)
             else:
                 ret = chr(j_char)

--- a/jnius/jnius_export_class.pxi
+++ b/jnius/jnius_export_class.pxi
@@ -1,5 +1,6 @@
 from cpython cimport PyObject
 from warnings import warn
+import sys
 
 
 class JavaException(Exception):
@@ -569,7 +570,10 @@ cdef class JavaField(object):
         elif r == 'C':
             j_char = j_env[0].GetCharField(
                     j_env, j_self, self.j_field)
-            ret = chr(j_char)
+            if sys.version_info < (3, 0):
+                ret = chr(<char>j_char)
+            else:
+                ret = chr(j_char)
         elif r == 'S':
             j_short = j_env[0].GetShortField(
                     j_env, j_self, self.j_field)
@@ -693,7 +697,10 @@ cdef class JavaField(object):
         elif r == 'C':
             j_char = j_env[0].GetStaticCharField(
                     j_env, self.j_cls, self.j_field)
-            ret = chr(j_char)
+            if sys.version_info < (3, 0):
+                ret = chr(<char>j_char)
+            else:
+                ret = chr(j_char)
         elif r == 'S':
             j_short = j_env[0].GetStaticShortField(
                     j_env, self.j_cls, self.j_field)
@@ -894,7 +901,10 @@ cdef class JavaMethod(object):
             with nogil:
                 j_char = j_env[0].CallCharMethodA(
                         j_env, j_self, self.j_method, j_args)
-            ret = chr(j_char)
+            if sys.version_info < (3, 0):
+                ret = chr(<char>j_char)
+            else:
+                ret = chr(j_char)
         elif r == 'S':
             with nogil:
                 j_short = j_env[0].CallShortMethodA(
@@ -982,7 +992,10 @@ cdef class JavaMethod(object):
             with nogil:
                 j_char = j_env[0].CallStaticCharMethodA(
                         j_env, self.j_cls, self.j_method, j_args)
-            ret = chr(j_char)
+            if sys.version_info < (3, 0):
+                ret = chr(<char>j_char)
+            else:
+                ret = chr(j_char)
         elif r == 'S':
             with nogil:
                 j_short = j_env[0].CallStaticShortMethodA(

--- a/jnius/jnius_export_class.pxi
+++ b/jnius/jnius_export_class.pxi
@@ -569,7 +569,7 @@ cdef class JavaField(object):
         elif r == 'C':
             j_char = j_env[0].GetCharField(
                     j_env, j_self, self.j_field)
-            ret = chr(<char>j_char)
+            ret = chr(j_char)
         elif r == 'S':
             j_short = j_env[0].GetShortField(
                     j_env, j_self, self.j_field)
@@ -693,7 +693,7 @@ cdef class JavaField(object):
         elif r == 'C':
             j_char = j_env[0].GetStaticCharField(
                     j_env, self.j_cls, self.j_field)
-            ret = chr(<char>j_char)
+            ret = chr(j_char)
         elif r == 'S':
             j_short = j_env[0].GetStaticShortField(
                     j_env, self.j_cls, self.j_field)
@@ -894,7 +894,7 @@ cdef class JavaMethod(object):
             with nogil:
                 j_char = j_env[0].CallCharMethodA(
                         j_env, j_self, self.j_method, j_args)
-            ret = chr(<char>j_char)
+            ret = chr(j_char)
         elif r == 'S':
             with nogil:
                 j_short = j_env[0].CallShortMethodA(
@@ -982,7 +982,7 @@ cdef class JavaMethod(object):
             with nogil:
                 j_char = j_env[0].CallStaticCharMethodA(
                         j_env, self.j_cls, self.j_method, j_args)
-            ret = chr(<char>j_char)
+            ret = chr(j_char)
         elif r == 'S':
             with nogil:
                 j_short = j_env[0].CallStaticShortMethodA(

--- a/tests/java-src/org/jnius/CharsAndStrings.java
+++ b/tests/java-src/org/jnius/CharsAndStrings.java
@@ -1,0 +1,82 @@
+package org.jnius;
+
+import java.lang.String;
+
+public class CharsAndStrings {
+  
+  public char testChar1;
+  public char testChar2;
+  public char testChar3;
+  public String testString1;
+  public String testString2;
+  public String testString3;
+  
+  static public char testStaticChar1 = 'a';
+  static public char testStaticChar2 = 'ä';
+  static public char testStaticChar3 = '☺';
+  static public String testStaticString1 = "hello world";
+  static public String testStaticString2 = "umlauts: äöü";
+  static public String testStaticString3 = "happy face: ☺";
+
+  public CharsAndStrings() {
+    this.testChar1 = 'a';
+    this.testChar2 = 'ä';
+    this.testChar3 = '☺';
+
+    this.testString1 = "hello world";
+    this.testString2 = "umlauts: äöü";
+    this.testString3 = "happy face: ☺";
+  }
+
+  public char testChar(int i, char testChar) {
+    if (i == 1) {
+      assert this.testChar1 == testChar;
+      return this.testChar1;
+    } else if (i == 2) {
+      assert this.testChar2 == testChar;
+      return this.testChar2;
+    } else {
+      assert this.testChar3 == testChar;
+      return this.testChar3;
+    }
+  }
+
+  static public char testStaticChar(int i, char testChar) {
+    if (i == 1) {
+      assert CharsAndStrings.testStaticChar1 == testChar;
+      return CharsAndStrings.testStaticChar1;
+    } else if (i == 2) {
+      assert CharsAndStrings.testStaticChar2 == testChar;
+      return CharsAndStrings.testStaticChar2;
+    } else {
+      assert CharsAndStrings.testStaticChar3 == testChar;
+      return CharsAndStrings.testStaticChar3;
+    }
+  }
+
+  public String testString(int i, String testString) {
+    if (i == 1) {
+      assert this.testString1.equals(testString);
+      return this.testString1;
+    } else if (i == 2) {
+      assert this.testString2.equals(testString);
+      return this.testString2;
+    } else {
+      assert this.testString3.equals(testString);
+      return this.testString3;
+    }
+  }
+
+  static public String testStaticString(int i, String testString) {
+    if (i == 1) {
+      assert CharsAndStrings.testStaticString1.equals(testString);
+      return CharsAndStrings.testStaticString1;
+    } else if (i == 2) {
+      assert CharsAndStrings.testStaticString2.equals(testString);
+      return CharsAndStrings.testStaticString2;
+    } else {
+      assert CharsAndStrings.testStaticString3.equals(testString);
+      return CharsAndStrings.testStaticString3;
+    }
+  }
+}

--- a/tests/java-src/org/jnius/CharsAndStrings.java
+++ b/tests/java-src/org/jnius/CharsAndStrings.java
@@ -18,6 +18,12 @@ public class CharsAndStrings {
   static public String testStaticString2 = "umlauts: äöü";
   static public String testStaticString3 = "happy face: ☺";
 
+  public char[] testCharArray1;
+  public char[] testCharArray2;
+  static public char[] testStaticCharArray1 = new char[]{'a', 'b', 'c'};
+  static public char[] testStaticCharArray2 = new char[]{'a', 'ä', '☺'};
+
+
   public CharsAndStrings() {
     this.testChar1 = 'a';
     this.testChar2 = 'ä';
@@ -26,6 +32,9 @@ public class CharsAndStrings {
     this.testString1 = "hello world";
     this.testString2 = "umlauts: äöü";
     this.testString3 = "happy face: ☺";
+
+    testCharArray1 = new char[]{'a', 'b', 'c'};
+    testCharArray2 = new char[]{'a', 'ä', '☺'};
   }
 
   public char testChar(int i, char testChar) {
@@ -77,6 +86,22 @@ public class CharsAndStrings {
     } else {
       assert CharsAndStrings.testStaticString3.equals(testString);
       return CharsAndStrings.testStaticString3;
+    }
+  }
+
+  public char[] testCharArray(int i) {
+    if (i == 1) {
+      return testCharArray1;
+    } else {
+      return testCharArray2;
+    }
+  }
+
+  static public char[] testStaticCharArray(int i) {
+    if (i == 1) {
+      return testStaticCharArray1;
+    } else {
+      return testStaticCharArray2;
     }
   }
 }

--- a/tests/test_chars_and_strings.py
+++ b/tests/test_chars_and_strings.py
@@ -81,3 +81,50 @@ class CharsAndStringsTest(unittest.TestCase):
         if sys.version_info.major >= 3:
             self.assertEqual(Test.testStaticString(2, "umlauts: äöü"), "umlauts: äöü")
             self.assertEqual(Test.testStaticString(3, "happy face: ☺"), "happy face: ☺")
+
+    def test_char_array(self):
+        Test = autoclass('org.jnius.CharsAndStrings',
+                         include_protected=False, include_private=False)
+        test = Test()
+
+        charArray1 = ['a', 'b', 'c']
+        charArray2 = ['a', 'ä', '☺']
+
+        for c1, c2 in zip(charArray1, test.testCharArray1):
+            self.assertEqual(c1, c2)
+        for c1, c2 in zip(charArray1, test.testCharArray(1)):
+            self.assertEqual(c1, c2)
+        if sys.version_info.major >= 3:
+            for c1, c2 in zip(charArray2, test.testCharArray2):
+                self.assertEqual(c1, c2)
+            for c1, c2 in zip(charArray2, test.testCharArray(2)):
+                self.assertEqual(c1, c2)
+
+    def test_static_char_array(self):
+        Test = autoclass('org.jnius.CharsAndStrings',
+                         include_protected=False, include_private=False)
+
+        charArray1 = ['a', 'b', 'c']
+        charArray2 = ['a', 'ä', '☺']
+
+        for c1, c2 in zip(charArray1, Test.testStaticCharArray1):
+            self.assertEqual(c1, c2)
+        for c1, c2 in zip(charArray1, Test.testStaticCharArray(1)):
+            self.assertEqual(c1, c2)
+        if sys.version_info.major >= 3:
+            for c1, c2 in zip(charArray2, Test.testStaticCharArray2):
+                self.assertEqual(c1, c2)
+            for c1, c2 in zip(charArray2, Test.testStaticCharArray(2)):
+                self.assertEqual(c1, c2)
+
+
+    def test_java_string(self):
+        JString = autoclass('java.lang.String')
+
+        testString1 = JString('hello world')
+        self.assertTrue(testString1.equals('hello world'))
+        if sys.version_info.major >= 3:
+            testString2 = JString('umlauts: äöü')
+            self.assertTrue(testString2.equals('umlauts: äöü'))
+            testString3 = JString('happy face: ☺')
+            self.assertTrue(testString3.equals('happy face: ☺'))

--- a/tests/test_chars_and_strings.py
+++ b/tests/test_chars_and_strings.py
@@ -1,0 +1,74 @@
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
+import sys
+import unittest
+from jnius.reflect import autoclass
+
+
+try:
+    long
+except NameError:
+    # Python 3
+    long = int
+
+
+def py2_encode(uni):
+    if sys.version_info < (3, 0):
+        uni = uni.encode('utf-8')
+    return uni
+
+
+class CharsAndStringsTest(unittest.TestCase):
+
+    def test_char_fields(self):
+        Test = autoclass('org.jnius.CharsAndStrings',
+                         include_protected=False, include_private=False)
+        test = Test()
+
+        self.assertEqual(test.testChar1, py2_encode('a'))
+        self.assertEqual(test.testChar2, py2_encode('ä'))
+        self.assertEqual(test.testChar3, py2_encode('☺'))
+
+        self.assertEqual(Test.testStaticChar1, py2_encode('a'))
+        self.assertEqual(Test.testStaticChar2, py2_encode('ä'))
+        self.assertEqual(Test.testStaticChar3, py2_encode('☺'))
+
+    def test_string_fields(self):
+        Test = autoclass('org.jnius.CharsAndStrings',
+                         include_protected=False, include_private=False)
+        test = Test()
+
+        self.assertEqual(test.testString1, py2_encode("hello world"))
+        self.assertEqual(test.testString2, py2_encode("umlauts: äöü"))
+        self.assertEqual(test.testString3, py2_encode("happy face: ☺"))
+
+        self.assertEqual(Test.testStaticString1, py2_encode("hello world"))
+        self.assertEqual(Test.testStaticString2, py2_encode("umlauts: äöü"))
+        self.assertEqual(Test.testStaticString3, py2_encode("happy face: ☺"))
+
+    def test_char_methods(self):
+        Test = autoclass('org.jnius.CharsAndStrings',
+                         include_protected=False, include_private=False)
+        test = Test()
+
+        self.assertEqual(test.testChar(1, 'a'), 'a')
+        self.assertEqual(test.testChar(2, 'ä'), 'ä')
+        self.assertEqual(test.testChar(3, '☺'), '☺')
+
+        self.assertEqual(Test.testStaticChar(1, 'a'), 'a')
+        self.assertEqual(Test.testStaticChar(2, 'ä'), 'ä')
+        self.assertEqual(Test.testStaticChar(3, '☺'), '☺')
+
+    def test_string_methods(self):
+        Test = autoclass('org.jnius.CharsAndStrings',
+                         include_protected=False, include_private=False)
+        test = Test()
+
+        self.assertEqual(test.testString(1, "hello world"), "hello world")
+        self.assertEqual(test.testString(2, "umlauts: äöü"), "umlauts: äöü")
+        self.assertEqual(test.testString(3, "happy face: ☺"), "happy face: ☺")
+
+        self.assertEqual(Test.testStaticString(1, "hello world"), "hello world")
+        self.assertEqual(Test.testStaticString(2, "umlauts: äöü"), "umlauts: äöü")
+        self.assertEqual(Test.testStaticString(3, "happy face: ☺"), "happy face: ☺")

--- a/tests/test_chars_and_strings.py
+++ b/tests/test_chars_and_strings.py
@@ -1,4 +1,5 @@
-from __future__ import print_function
+# -*- coding: utf-8 -*-
+# from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
 import sys
@@ -27,12 +28,14 @@ class CharsAndStringsTest(unittest.TestCase):
         test = Test()
 
         self.assertEqual(test.testChar1, py2_encode('a'))
-        self.assertEqual(test.testChar2, py2_encode('ä'))
-        self.assertEqual(test.testChar3, py2_encode('☺'))
+        if sys.version_info.major >= 3:
+            self.assertEqual(test.testChar2, 'ä')
+            self.assertEqual(test.testChar3, '☺')
 
         self.assertEqual(Test.testStaticChar1, py2_encode('a'))
-        self.assertEqual(Test.testStaticChar2, py2_encode('ä'))
-        self.assertEqual(Test.testStaticChar3, py2_encode('☺'))
+        if sys.version_info.major >= 3:
+            self.assertEqual(Test.testStaticChar2, 'ä')
+            self.assertEqual(Test.testStaticChar3, '☺')
 
     def test_string_fields(self):
         Test = autoclass('org.jnius.CharsAndStrings',
@@ -40,35 +43,41 @@ class CharsAndStringsTest(unittest.TestCase):
         test = Test()
 
         self.assertEqual(test.testString1, py2_encode("hello world"))
-        self.assertEqual(test.testString2, py2_encode("umlauts: äöü"))
-        self.assertEqual(test.testString3, py2_encode("happy face: ☺"))
+        if sys.version_info.major >= 3:
+            self.assertEqual(test.testString2, "umlauts: äöü")
+            self.assertEqual(test.testString3, "happy face: ☺")
 
         self.assertEqual(Test.testStaticString1, py2_encode("hello world"))
-        self.assertEqual(Test.testStaticString2, py2_encode("umlauts: äöü"))
-        self.assertEqual(Test.testStaticString3, py2_encode("happy face: ☺"))
+        if sys.version_info.major >= 3:
+            self.assertEqual(Test.testStaticString2, "umlauts: äöü")
+            self.assertEqual(Test.testStaticString3, "happy face: ☺")
 
     def test_char_methods(self):
         Test = autoclass('org.jnius.CharsAndStrings',
                          include_protected=False, include_private=False)
         test = Test()
 
-        self.assertEqual(test.testChar(1, 'a'), 'a')
-        self.assertEqual(test.testChar(2, 'ä'), 'ä')
-        self.assertEqual(test.testChar(3, '☺'), '☺')
+        self.assertEqual(test.testChar(1, py2_encode('a')), py2_encode('a'))
+        if sys.version_info.major >= 3:
+            self.assertEqual(test.testChar(2, 'ä'), 'ä')
+            self.assertEqual(test.testChar(3, '☺'), '☺')
 
-        self.assertEqual(Test.testStaticChar(1, 'a'), 'a')
-        self.assertEqual(Test.testStaticChar(2, 'ä'), 'ä')
-        self.assertEqual(Test.testStaticChar(3, '☺'), '☺')
+        self.assertEqual(Test.testStaticChar(1, py2_encode('a')), py2_encode('a'))
+        if sys.version_info.major >= 3:
+            self.assertEqual(Test.testStaticChar(2, 'ä'), 'ä')
+            self.assertEqual(Test.testStaticChar(3, '☺'), '☺')
 
     def test_string_methods(self):
         Test = autoclass('org.jnius.CharsAndStrings',
                          include_protected=False, include_private=False)
         test = Test()
 
-        self.assertEqual(test.testString(1, "hello world"), "hello world")
-        self.assertEqual(test.testString(2, "umlauts: äöü"), "umlauts: äöü")
-        self.assertEqual(test.testString(3, "happy face: ☺"), "happy face: ☺")
+        self.assertEqual(test.testString(1, py2_encode("hello world")), py2_encode("hello world"))
+        if sys.version_info.major >= 3:
+            self.assertEqual(test.testString(2, "umlauts: äöü"), "umlauts: äöü")
+            self.assertEqual(test.testString(3, "happy face: ☺"), "happy face: ☺")
 
-        self.assertEqual(Test.testStaticString(1, "hello world"), "hello world")
-        self.assertEqual(Test.testStaticString(2, "umlauts: äöü"), "umlauts: äöü")
-        self.assertEqual(Test.testStaticString(3, "happy face: ☺"), "happy face: ☺")
+        self.assertEqual(Test.testStaticString(1, py2_encode("hello world")), py2_encode("hello world"))
+        if sys.version_info.major >= 3:
+            self.assertEqual(Test.testStaticString(2, "umlauts: äöü"), "umlauts: äöü")
+            self.assertEqual(Test.testStaticString(3, "happy face: ☺"), "happy face: ☺")


### PR DESCRIPTION
Java `char` [datatypes](https://docs.oracle.com/javase/tutorial/java/nutsandbolts/datatypes.html) have a maximum value of `0xFFFF` but Python `chr` go up to `0x110000`. But in `jnius_export_class.pxi` there are `<char>` casts like `chr(<char>j_char)` to read char fields or  char method return values. But this is not correct if `j_char` is greater than 255. Taking out the casts allows for more characters.