### PR TITLE
Refactor of env.py

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,34 @@
 # Change Log
 
+## [1.3.0](https://github.com/kivy/pyjnius/tree/1.3.0) (2020-05-03)
+[Full Changelog](https://github.com/kivy/pyjnius/compare/1.2.1...1.3.0)
+
+**Implemented enhancements:**
+- [\#483](https://github.com/kivy/pyjnius/pull/483)/[\#489](https://github.com/kivy/pyjnius/pull/489) allow passing a `signature` argument to constructors, to force selection of the desired one
+- [\#497](https://github.com/kivy/pyjnius/pull/497)/[\#506](https://github.com/kivy/pyjnius/pull/506)/[\#507](https://github.com/kivy/pyjnius/pull/507) support for more "dunder" methods/protocols on compatible interfaces than just `__len__`, and allow users to provide their own.
+- [\#500](https://github.com/kivy/pyjnius/pull/500)[\#522](https://github.com/kivy/pyjnius/pull/522) allow ignoring private methods and fields in autoclass (both default to False)
+- [\#503](https://github.com/kivy/pyjnius/pull/503) auto detect java_home on OSX, using `/usr/libexec/java_home` (if JAVA_HOME is not declared)
+- [\#514](https://github.com/kivy/pyjnius/pull/514) writing to static fields (and fix reading from them)
+- [\#517](https://github.com/kivy/pyjnius/pull/517) make signature exceptions more useful
+- [\#502](https://github.com/kivy/pyjnius/pull/502) provide a stacktrace for where JVM was started.
+- [\#523](https://github.com/kivy/pyjnius/pull/523) expose the class's class attribute
+- [\#524](https://github.com/kivy/pyjnius/pull/524) fix handling of Java chars > 256 in Python3
+- [\#519](https://github.com/kivy/pyjnius/pull/519) Always show the exception name
+
+**Fixed bugs:**
+- [\#481](https://github.com/kivy/pyjnius/pull/481) wrong use of strip on JRE path
+- [\#465](https://github.com/kivy/pyjnius/pull/465) correct reflection to avoid missing any methods from parent classes or interfaces
+- [\#508](https://github.com/kivy/pyjnius/pull/508) don't had error details with a custom exception when java class is not found
+- [\#510](https://github.com/kivy/pyjnius/pull/510) add missing references to .pxi files in setup.py, speeding up recompilation
+- [\#518](https://github.com/kivy/pyjnius/pull/518) ensure autoclass prefers methods over properties
+- [\#520](https://github.com/kivy/pyjnius/pull/520) improved discovery of libjvm.so + provide a workaround if it doesn't work
+
+**Documentation**
+- [\#478](https://github.com/kivy/pyjnius/pull/478) document automatic Thread detach feature
+- [\#512](https://github.com/kivy/pyjnius/pull/512) document the requirement to keep reference to object/functions passed to java, for as long as it might use them
+- [\#521](https://github.com/kivy/pyjnius/pull/521) fix inheritance in example
+
+
 ## [1.2.1](https://github.com/kivy/pyjnius/tree/1.2.1) (2019-12-04)
 [Full Changelog](https://github.com/kivy/pyjnius/compare/1.2.0...1.2.1)
 

--- a/jnius/__init__.py
+++ b/jnius/__init__.py
@@ -9,13 +9,14 @@ All the documentation is available at: http://pyjnius.readthedocs.org
 
 __version__ = '1.3.0'
 
-from .env import get_jnius_lib_location, get_jdk_home
+from .env import get_java_setup
 
 import os
 import sys
 if sys.platform == 'win32' and sys.version_info >= (3, 8):
     path = os.path.dirname(__file__)
-    jdk_home = get_jdk_home(sys.platform)
+    java = get_java_setup(sys.platform)
+    jdk_home = java.get_javahome()
     with os.add_dll_directory(path):
         for suffix in (
             ('bin', 'client'),

--- a/jnius/__init__.py
+++ b/jnius/__init__.py
@@ -7,7 +7,7 @@ Accessing Java classes from Python.
 All the documentation is available at: http://pyjnius.readthedocs.org
 '''
 
-__version__ = '1.2.2-dev0'
+__version__ = '1.3.0'
 
 from .env import get_jnius_lib_location, get_jdk_home
 

--- a/jnius/env.py
+++ b/jnius/env.py
@@ -227,14 +227,11 @@ class UnixJavaLocation(JavaLocation):
 
 class MacOsXJavaLocation(UnixJavaLocation):
     
-    def __init__():
-        self.platform = platform
-    
     def _get_platform_include_dir(self):
-        return join(jdk_home, 'include', 'darwin')
+        return join(self.home, 'include', 'darwin')
 
     def _possible_lib_locations(self, cpu):
-        if '1.6' in self.root:
+        if '1.6' in self.home:
             return ['../Libraries/libjvm.dylib'] # TODO what should this be resolved to?
 
         return [
@@ -261,12 +258,14 @@ class MacOsXJavaLocation(UnixJavaLocation):
 
 class AndroidJavaLocation(UnixJavaLocation):
     
-    def get_libraries(platform):
+    def get_libraries(self):
         #if platform == 'android':
         # for android, we use SDL...
         return ['sdl', 'log']
 
     def get_library_dirs(self):
+        raise RuntimeError("TODO: who sets arch?")
+        arch = None
         return [join(self.home, 'libs', arch)]
 
 

--- a/jnius/env.py
+++ b/jnius/env.py
@@ -279,6 +279,16 @@ def get_jre_home(platform):
             ).decode('utf-8').strip()
         ).replace('bin/java', '')
 
+        if is_set(jre_home):
+            return jre_home
+    
+        # didnt find java command on the path, we can
+        # fallback to hunting in some default unix locations
+        for loc in ["/usr/java/latest/", "/usr/java/default/", "/usr/lib/jvm/default-java/"]: 
+            if exists(loc + "bin/java"):
+                jre_home = loc
+                break
+
     return jre_home
 
 

--- a/jnius/jnius_jvm_desktop.pxi
+++ b/jnius/jnius_jvm_desktop.pxi
@@ -1,7 +1,7 @@
 import sys
 import os
 from os.path import join
-from jnius.env import get_jdk_home
+from jnius.env import get_java_setup
 from cpython.version cimport PY_MAJOR_VERSION
 
 # on desktop, we need to create an env :)
@@ -49,7 +49,8 @@ cdef void create_jnienv() except *:
 
     if sys.version_info >= (3, 8):
         # uh, let's see if this works and cleanup later
-        jdk_home = get_jdk_home('win32')
+        java = get_java_setup('win32')
+        jdk_home = java.get_javahome()
         for suffix in (
             ('bin', 'client'),
             ('bin', 'server'),

--- a/jnius/jnius_jvm_dlopen.pxi
+++ b/jnius/jnius_jvm_dlopen.pxi
@@ -98,7 +98,7 @@ cdef void create_jnienv() except *:
     handle = dlopen(lib_path, RTLD_NOW | RTLD_GLOBAL)
 
     if handle == NULL:
-        raise SystemError("Error calling dlopen({0}: {1}".format(lib_path, dlerror()))
+        raise SystemError("Error calling dlopen({0}): {1}".format(lib_path, dlerror()))
 
     cdef void *jniCreateJVM = dlsym(handle, b"JNI_CreateJavaVM")
 

--- a/setup.py
+++ b/setup.py
@@ -22,12 +22,8 @@ from setup_sdist import SETUP_KWARGS
 syspath = sys.path[:]
 sys.path.insert(0, 'jnius')
 from env import (
-    get_possible_homes,
-    get_library_dirs,
-    get_include_dirs,
-    get_libraries,
-    find_javac,
-    PY2,
+    get_java_setup,
+    PY2
 )
 sys.path = syspath
 
@@ -76,10 +72,13 @@ if PLATFORM != 'android':
 else:
     FILES = [fn[:-3] + 'c' for fn in FILES if fn.endswith('pyx')]
 
+JAVA=get_java_setup(PLATFORM)
 
-def compile_native_invocation_handler(*possible_homes):
+assert JAVA.is_jdk(), "You need a JDK, we only found a JRE. Try setting JAVA_HOME"
+
+def compile_native_invocation_handler(java):
     '''Find javac and compile NativeInvocationHandler.java.'''
-    javac = find_javac(PLATFORM, possible_homes)
+    javac = java.get_javac()
     source_level = '1.7'
     try:
         subprocess.check_call([
@@ -92,7 +91,7 @@ def compile_native_invocation_handler(*possible_homes):
             join('jnius', 'src', 'org', 'jnius', 'NativeInvocationHandler.java')
         ])
 
-compile_native_invocation_handler(*get_possible_homes(PLATFORM))
+compile_native_invocation_handler(JAVA)
 
 
 # generate the config.pxi
@@ -116,9 +115,9 @@ setup(
     ext_modules=[
         Extension(
             'jnius', [join('jnius', x) for x in FILES],
-            libraries=get_libraries(PLATFORM),
-            library_dirs=get_library_dirs(PLATFORM),
-            include_dirs=get_include_dirs(PLATFORM),
+            libraries=JAVA.get_libraries(),
+            library_dirs=JAVA.get_library_dirs(),
+            include_dirs=JAVA.get_include_dirs(),
             extra_link_args=EXTRA_LINK_ARGS,
         )
     ],


### PR DESCRIPTION
Please consider this PR for review and testing.

I couldn't see an easy way to fix the challenge posed in #537, so I refactored env.py. There is now a base class for JavaLocation, which is overridden in platform specific manners. The role of each method is clearly specified. We also use a common, one-time logic for identifying the location of Java.

I have tested on:
 - Mac with no JAVA_HOME set, OpenJDK13
 - Linux without JAVA_HOME set
 - Linux with JAVA_HOME set to Java 8 JDK
 - Linux with JAVA_HOME set to Java 11 JDK
 - Google Colab linux, OpenJDK 11, no JAVA_HOME set

It requires testing on:
 - Windows
 - Android. NB: A TODO for Android.
 - Linux and Mac with adoptjdk? And also _running_ using JREs after building with JDKs.

Semantics changes:
 - JAVA_HOME env var takes precedence over everything else now, systematically
 - JVM_PATH env var takes an absolute path rather than a relative one
 - All methods return absolute paths, rather than the confusion of relative paths

We should also write a unit test for env.py