### PR TITLE
Improve performance of byte array parameters

### DIFF
--- a/jnius/jnius_conversion.pxi
+++ b/jnius/jnius_conversion.pxi
@@ -21,7 +21,7 @@ cdef void release_args(JNIEnv *j_env, tuple definition_args, bint pass_by_refere
                     jstringy_arg(argtype):
                 j_env[0].DeleteLocalRef(j_env, j_args[index].l)
         elif argtype[0] == '[':
-            if pass_by_reference:
+            if pass_by_reference and hasattr(args[index], '__setitem__'):
                 ret = convert_jarray_to_python(j_env, argtype[1:], j_args[index].l)
                 try:
                     args[index][:] = ret

--- a/jnius/jnius_conversion.pxi
+++ b/jnius/jnius_conversion.pxi
@@ -21,7 +21,6 @@ cdef void release_args(JNIEnv *j_env, tuple definition_args, bint pass_by_refere
                     jstringy_arg(argtype):
                 j_env[0].DeleteLocalRef(j_env, j_args[index].l)
         elif argtype[0] == '[':
-            # if getattr(py_arg, '_JNIUS_PASS_BY_REFERENCE', True):
             if pass_by_reference:
                 ret = convert_jarray_to_python(j_env, argtype[1:], j_args[index].l)
                 try:
@@ -587,12 +586,6 @@ cdef jobject convert_pyarray_to_java(JNIEnv *j_env, definition, pyarray) except 
             a_bytes = pyarray
             j_env[0].SetByteArrayRegion(j_env,
                 ret, 0, array_size, <const_jbyte *>a_bytes._buf)
-            ## this makes ByteArrays slow
-            # for i in range(array_size):
-            #     c_tmp = pyarray[i]
-            #     j_byte = <signed char>c_tmp
-            #     j_env[0].SetByteArrayRegion(j_env,
-            #             ret, i, 1, &j_byte)
         elif isinstance(pyarray, (bytearray, bytes)):
             j_bytes = <signed char *>pyarray
             j_env[0].SetByteArrayRegion(j_env,

--- a/jnius/jnius_conversion.pxi
+++ b/jnius/jnius_conversion.pxi
@@ -593,7 +593,7 @@ cdef jobject convert_pyarray_to_java(JNIEnv *j_env, definition, pyarray) except 
             #     j_byte = <signed char>c_tmp
             #     j_env[0].SetByteArrayRegion(j_env,
             #             ret, i, 1, &j_byte)
-        elif isinstance(pyarray, bytearray):
+        elif isinstance(pyarray, (bytearray, bytes)):
             j_bytes = <signed char *>pyarray
             j_env[0].SetByteArrayRegion(j_env,
                 ret, 0, array_size, j_bytes)

--- a/jnius/jnius_conversion.pxi
+++ b/jnius/jnius_conversion.pxi
@@ -21,11 +21,12 @@ cdef void release_args(JNIEnv *j_env, tuple definition_args, jvalue *j_args, arg
                     jstringy_arg(argtype):
                 j_env[0].DeleteLocalRef(j_env, j_args[index].l)
         elif argtype[0] == '[':
-            ret = convert_jarray_to_python(j_env, argtype[1:], j_args[index].l)
-            try:
-                args[index][:] = ret
-            except TypeError:
-                pass
+            if not getattr(py_arg, '_JNIUS_PASS_BY_VALUE', False):
+                ret = convert_jarray_to_python(j_env, argtype[1:], j_args[index].l)
+                try:
+                    args[index][:] = ret
+                except TypeError:
+                    pass
             j_env[0].DeleteLocalRef(j_env, j_args[index].l)
 
 cdef void populate_args(JNIEnv *j_env, tuple definition_args, jvalue *j_args, args) except *:

--- a/jnius/jnius_export_class.pxi
+++ b/jnius/jnius_export_class.pxi
@@ -365,7 +365,7 @@ cdef class JavaClass(object):
                     constructor, j_args)
 
             # release our arguments
-            release_args(j_env, d_args, j_args, args_)
+            release_args(j_env, d_args, True, j_args, args_)
 
             check_exception(j_env)
             if j_self == NULL:
@@ -759,6 +759,7 @@ cdef class JavaMethod(object):
     cdef bint is_varargs
     cdef object definition_return
     cdef object definition_args
+    cdef bint _pass_by_reference
 
     def __cinit__(self, definition, **kwargs):
         self.j_method = NULL
@@ -768,9 +769,13 @@ cdef class JavaMethod(object):
     def signatures(self):
         return list([readable_sig(self.definition, self.is_varargs)])
 
+    def pass_by_reference(self, val):
+        self._pass_by_reference = val
+
     def __init__(self, definition, **kwargs):
         super(JavaMethod, self).__init__()
         self.definition = definition
+        self._pass_by_reference = True
         self.definition_return, self.definition_args = parse_definition(
             definition
         )
@@ -856,7 +861,7 @@ cdef class JavaMethod(object):
                     return self.call_staticmethod(j_env, j_args)
                 return self.call_method(j_env, j_args)
             finally:
-                release_args(j_env, self.definition_args, j_args, args)
+                release_args(j_env, self.definition_args, self._pass_by_reference, j_args, args)
 
         finally:
             if j_args != NULL:
@@ -1054,9 +1059,13 @@ cdef class JavaMultipleMethod(object):
     cdef dict instance_methods
     cdef bytes name
     cdef bytes classname
+    cdef bint _pass_by_reference
 
     def signatures(self):
         return [readable_sig(args, is_varargs) for args, static, is_varargs in self.definitions]
+
+    def pass_by_reference(self, val):
+        self._pass_by_reference = val
 
     def __cinit__(self, definition, **kwargs):
         self.j_self = None
@@ -1067,6 +1076,7 @@ cdef class JavaMultipleMethod(object):
         self.static_methods = {}
         self.instance_methods = {}
         self.name = None
+        self._pass_by_reference = True
 
     def __get__(self, obj, objtype):
         if obj is None:
@@ -1141,6 +1151,7 @@ cdef class JavaMultipleMethod(object):
         score, signature = scores[-1]
 
         jm = methods[signature]
+        jm.pass_by_reference(self._pass_by_reference)
         jm.j_self = self.j_self
         return jm.__call__(*args)
 

--- a/jnius/jnius_export_class.pxi
+++ b/jnius/jnius_export_class.pxi
@@ -360,12 +360,16 @@ cdef class JavaClass(object):
                 raise JavaException('Unable to found the constructor'
                         ' for {0}'.format(self.__javaclass__))
 
+            # determine pass by reference choices
+            pass_by_reference = kwargs.get('pass_by_reference', True)
+            pass_by_reference = pass_by_reference if isinstance(pass_by_reference, (tuple, list)) else [pass_by_reference]
+
             # create the object
             j_self = j_env[0].NewObjectA(j_env, self.j_cls,
                     constructor, j_args)
 
             # release our arguments
-            release_args(j_env, d_args, kwargs.get('pass_by_reference', True), j_args, args_)
+            release_args(j_env, d_args, pass_by_reference, j_args, args_)
 
             check_exception(j_env)
             if j_self == NULL:
@@ -835,6 +839,10 @@ cdef class JavaMethod(object):
                     self.classname, self.name) 
             )
 
+        # determine pass by reference choices
+        pass_by_reference = kwargs.get('pass_by_reference', True)
+        pass_by_reference = pass_by_reference if isinstance(pass_by_reference, (tuple, list)) else [pass_by_reference]
+
         if not self.is_static and j_env == NULL:
             raise JavaException(
                 'Cannot call instance method on a un-instanciated class'
@@ -856,7 +864,7 @@ cdef class JavaMethod(object):
                     return self.call_staticmethod(j_env, j_args)
                 return self.call_method(j_env, j_args)
             finally:
-                release_args(j_env, self.definition_args, kwargs.get('pass_by_reference', True), j_args, args)
+                release_args(j_env, self.definition_args, pass_by_reference, j_args, args)
 
         finally:
             if j_args != NULL:

--- a/jnius/jnius_nativetypes3.pxi
+++ b/jnius/jnius_nativetypes3.pxi
@@ -18,13 +18,13 @@ cdef class ByteArray:
     cdef long _size
     cdef unsigned char *_buf
     cdef unsigned char[:] _arr
-    cdef public bint _JNIUS_PASS_BY_VALUE
+    cdef public bint _JNIUS_PASS_BY_REFERENCE
 
     def __cinit__(self):
         self._size = 0
         self._buf = NULL
         self._arr = None
-        self._JNIUS_PASS_BY_VALUE = False
+        self._JNIUS_PASS_BY_REFERENCE = True
 
     def __dealloc__(self):
         cdef JNIEnv *j_env
@@ -69,7 +69,6 @@ cdef class ByteArray:
     def __setitem__(self, index, val):
         cdef long xx
         cdef int x
-        # cdef long jj
         cdef unsigned char *vals
         cdef long start
         cdef long stop
@@ -85,6 +84,9 @@ cdef class ByteArray:
         else:
             xx = index
             self._arr[xx] = val
+
+    def pass_by_reference(self, pref):
+        self._JNIUS_PASS_BY_REFERENCE = pref
 
     def __richcmp__(self, other, op):
         cdef ByteArray b_other

--- a/jnius/jnius_nativetypes3.pxi
+++ b/jnius/jnius_nativetypes3.pxi
@@ -18,13 +18,11 @@ cdef class ByteArray:
     cdef long _size
     cdef unsigned char *_buf
     cdef unsigned char[:] _arr
-    cdef public bint _JNIUS_PASS_BY_REFERENCE
 
     def __cinit__(self):
         self._size = 0
         self._buf = NULL
         self._arr = None
-        self._JNIUS_PASS_BY_REFERENCE = True
 
     def __dealloc__(self):
         cdef JNIEnv *j_env
@@ -65,28 +63,6 @@ cdef class ByteArray:
         else:
             xx = index
             return self._arr[xx]
-
-    def __setitem__(self, index, val):
-        cdef long xx
-        cdef int x
-        cdef unsigned char *vals
-        cdef long start
-        cdef long stop
-        cdef long step
-        if isinstance(index, slice):
-            vals = val
-            if self._size:
-                (start, stop, step) = index.indices(self._size)
-                # the following is faster than `range(start, stop, step)`
-                for x in range(((step - 1) + stop - start) // step):
-                    xx = x
-                    self._arr[start + xx * step] = vals[xx]
-        else:
-            xx = index
-            self._arr[xx] = val
-
-    def pass_by_reference(self, pref):
-        self._JNIUS_PASS_BY_REFERENCE = pref
 
     def __richcmp__(self, other, op):
         cdef ByteArray b_other

--- a/tests/java-src/org/jnius/VariablePassing.java
+++ b/tests/java-src/org/jnius/VariablePassing.java
@@ -1,0 +1,32 @@
+package org.jnius;
+
+public class VariablePassing {
+
+  private static void squareNumbers(int[] numbers) {
+    for (int i = 0; i < numbers.length; i++) {
+      numbers[i] = i * i;
+    }
+  }
+
+  public static void singleParamStatic(int[] numbers) {
+    squareNumbers(numbers);
+  }
+
+  public static void multipleParamsStatic(int[] numbers1, int[] numbers2, int[] numbers3, int[] numbers4) {
+    squareNumbers(numbers1);
+    squareNumbers(numbers2);
+    squareNumbers(numbers3);
+    squareNumbers(numbers4);
+  }
+
+  public void singleParam(int[] numbers) {
+    squareNumbers(numbers);
+  }
+
+  public void multipleParams(int[] numbers1, int[] numbers2, int[] numbers3, int[] numbers4) {
+    squareNumbers(numbers1);
+    squareNumbers(numbers2);
+    squareNumbers(numbers3);
+    squareNumbers(numbers4);
+  }
+}

--- a/tests/java-src/org/jnius/VariablePassing.java
+++ b/tests/java-src/org/jnius/VariablePassing.java
@@ -2,6 +2,21 @@ package org.jnius;
 
 public class VariablePassing {
 
+  public VariablePassing() {
+
+  }
+
+  public VariablePassing(int[] numbers) {
+    squareNumbers(numbers);
+  }
+
+  public VariablePassing(int[] numbers1, int[] numbers2, int[] numbers3, int[] numbers4) {
+    squareNumbers(numbers1);
+    squareNumbers(numbers2);
+    squareNumbers(numbers3);
+    squareNumbers(numbers4);
+  }
+
   private static void squareNumbers(int[] numbers) {
     for (int i = 0; i < numbers.length; i++) {
       numbers[i] = i * i;

--- a/tests/test_pass_by_reference_or_value.py
+++ b/tests/test_pass_by_reference_or_value.py
@@ -14,9 +14,8 @@ class PassByReferenceOrValueTest(unittest.TestCase):
             for n, c in zip(numbers, changed):
                 self._verify(n, c)
 
-    def test_single_param(self):
+    def test_single_param_static(self):
         VariablePassing = autoclass('org.jnius.VariablePassing')
-        variablePassing = VariablePassing()
 
         # passed by reference (default), numbers should change
         numbers = list(range(10))
@@ -33,6 +32,10 @@ class PassByReferenceOrValueTest(unittest.TestCase):
         VariablePassing.singleParamStatic(numbers, pass_by_reference=False)
         self._verify(numbers, False)
 
+    def test_single_param(self):
+        VariablePassing = autoclass('org.jnius.VariablePassing')
+        variablePassing = VariablePassing()
+
         # passed by reference (default), numbers should change
         numbers = list(range(10))
         variablePassing.singleParam(numbers)
@@ -48,9 +51,8 @@ class PassByReferenceOrValueTest(unittest.TestCase):
         variablePassing.singleParam(numbers, pass_by_reference=False)
         self._verify(numbers, False)
 
-    def test_multiple_params(self):
+    def test_multiple_params_static(self):
         VariablePassing = autoclass('org.jnius.VariablePassing')
-        variablePassing = VariablePassing()
 
         # passed by reference (default), all numbers should change
         numbers = [list(range(10)) for _ in range(4)]
@@ -87,4 +89,103 @@ class PassByReferenceOrValueTest(unittest.TestCase):
         numbers = [list(range(10)) for _ in range(4)]
         changed = (False, True, False, True)
         VariablePassing.multipleParamsStatic(*numbers, pass_by_reference=changed)
+        self._verify_all(numbers, changed)
+
+    def test_multiple_params(self):
+        VariablePassing = autoclass('org.jnius.VariablePassing')
+        variablePassing = VariablePassing()
+
+        # passed by reference (default), all numbers should change
+        numbers = [list(range(10)) for _ in range(4)]
+        variablePassing.multipleParams(*numbers)
+        self._verify_all(numbers, [True] * 4)
+
+        # passed by reference, all numbers should change
+        numbers = [list(range(10)) for _ in range(4)]
+        variablePassing.multipleParams(*numbers, pass_by_reference=True)
+        self._verify_all(numbers, [True] * 4)
+
+        # passed by value, no numbers should change
+        numbers = [list(range(10)) for _ in range(4)]
+        variablePassing.multipleParams(*numbers, pass_by_reference=False)
+        self._verify_all(numbers, [False] * 4)
+
+        # only the first set of numbers should change
+        numbers = [list(range(10)) for _ in range(4)]
+        variablePassing.multipleParams(*numbers, pass_by_reference=[True, False])
+        self._verify_all(numbers, [True, False, False, False])
+
+        # only the first set of numbers should not change
+        numbers = [list(range(10)) for _ in range(4)]
+        variablePassing.multipleParams(*numbers, pass_by_reference=[False, True])
+        self._verify_all(numbers, [False, True, True, True])
+
+        # only the odd sets of numbers should change
+        numbers = [list(range(10)) for _ in range(4)]
+        changed = (True, False, True, False)
+        variablePassing.multipleParams(*numbers, pass_by_reference=changed)
+        self._verify_all(numbers, changed)
+
+        # only the even sets of numbers should change
+        numbers = [list(range(10)) for _ in range(4)]
+        changed = (False, True, False, True)
+        variablePassing.multipleParams(*numbers, pass_by_reference=changed)
+        self._verify_all(numbers, changed)
+
+    def test_contructor_single_param(self):
+        VariablePassing = autoclass('org.jnius.VariablePassing')
+
+        # passed by reference (default), numbers should change
+        numbers = list(range(10))
+        variablePassing = VariablePassing(numbers)
+        self._verify(numbers, True)
+
+        # passed by reference, numbers should change
+        numbers = list(range(10))
+        variablePassing = VariablePassing(numbers, pass_by_reference=True)
+        self._verify(numbers, True)
+
+        # passed by value, numbers should not change
+        numbers = list(range(10))
+        variablePassing = VariablePassing(numbers, pass_by_reference=False)
+        self._verify(numbers, False)
+
+    def test_contructor_multiple_params(self):
+        VariablePassing = autoclass('org.jnius.VariablePassing')
+
+        # passed by reference (default), all numbers should change
+        numbers = [list(range(10)) for _ in range(4)]
+        variablePassing = VariablePassing(*numbers)
+        self._verify_all(numbers, [True] * 4)
+
+        # passed by reference, all numbers should change
+        numbers = [list(range(10)) for _ in range(4)]
+        variablePassing = VariablePassing(*numbers, pass_by_reference=True)
+        self._verify_all(numbers, [True] * 4)
+
+        # passed by value, no numbers should change
+        numbers = [list(range(10)) for _ in range(4)]
+        variablePassing = VariablePassing(*numbers, pass_by_reference=False)
+        self._verify_all(numbers, [False] * 4)
+
+        # only the first set of numbers should change
+        numbers = [list(range(10)) for _ in range(4)]
+        variablePassing = VariablePassing(*numbers, pass_by_reference=[True, False])
+        self._verify_all(numbers, [True, False, False, False])
+
+        # only the first set of numbers should not change
+        numbers = [list(range(10)) for _ in range(4)]
+        variablePassing = VariablePassing(*numbers, pass_by_reference=[False, True])
+        self._verify_all(numbers, [False, True, True, True])
+
+        # only the odd sets of numbers should change
+        numbers = [list(range(10)) for _ in range(4)]
+        changed = (True, False, True, False)
+        variablePassing = VariablePassing(*numbers, pass_by_reference=changed)
+        self._verify_all(numbers, changed)
+
+        # only the even sets of numbers should change
+        numbers = [list(range(10)) for _ in range(4)]
+        changed = (False, True, False, True)
+        variablePassing = VariablePassing(*numbers, pass_by_reference=changed)
         self._verify_all(numbers, changed)

--- a/tests/test_pass_by_reference_or_value.py
+++ b/tests/test_pass_by_reference_or_value.py
@@ -1,0 +1,90 @@
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
+import unittest
+from jnius import autoclass
+
+class PassByReferenceOrValueTest(unittest.TestCase):
+
+    def _verify(self, numbers, changed):
+        for i in range(len(numbers)):
+            self.assertEqual(numbers[i], i * i if changed else i)
+
+    def _verify_all(self, numbers, changed):
+            for n, c in zip(numbers, changed):
+                self._verify(n, c)
+
+    def test_single_param(self):
+        VariablePassing = autoclass('org.jnius.VariablePassing')
+        variablePassing = VariablePassing()
+
+        # passed by reference (default), numbers should change
+        numbers = list(range(10))
+        VariablePassing.singleParamStatic(numbers)
+        self._verify(numbers, True)
+
+        # passed by reference, numbers should change
+        numbers = list(range(10))
+        VariablePassing.singleParamStatic(numbers, pass_by_reference=True)
+        self._verify(numbers, True)
+
+        # passed by value, numbers should not change
+        numbers = list(range(10))
+        VariablePassing.singleParamStatic(numbers, pass_by_reference=False)
+        self._verify(numbers, False)
+
+        # passed by reference (default), numbers should change
+        numbers = list(range(10))
+        variablePassing.singleParam(numbers)
+        self._verify(numbers, True)
+
+        # passed by reference, numbers should change
+        numbers = list(range(10))
+        variablePassing.singleParam(numbers, pass_by_reference=True)
+        self._verify(numbers, True)
+
+        # passed by value, numbers should not change
+        numbers = list(range(10))
+        variablePassing.singleParam(numbers, pass_by_reference=False)
+        self._verify(numbers, False)
+
+    def test_multiple_params(self):
+        VariablePassing = autoclass('org.jnius.VariablePassing')
+        variablePassing = VariablePassing()
+
+        # passed by reference (default), all numbers should change
+        numbers = [list(range(10)) for _ in range(4)]
+        VariablePassing.multipleParamsStatic(*numbers)
+        self._verify_all(numbers, [True] * 4)
+
+        # passed by reference, all numbers should change
+        numbers = [list(range(10)) for _ in range(4)]
+        VariablePassing.multipleParamsStatic(*numbers, pass_by_reference=True)
+        self._verify_all(numbers, [True] * 4)
+
+        # passed by value, no numbers should change
+        numbers = [list(range(10)) for _ in range(4)]
+        VariablePassing.multipleParamsStatic(*numbers, pass_by_reference=False)
+        self._verify_all(numbers, [False] * 4)
+
+        # only the first set of numbers should change
+        numbers = [list(range(10)) for _ in range(4)]
+        VariablePassing.multipleParamsStatic(*numbers, pass_by_reference=[True, False])
+        self._verify_all(numbers, [True, False, False, False])
+
+        # only the first set of numbers should not change
+        numbers = [list(range(10)) for _ in range(4)]
+        VariablePassing.multipleParamsStatic(*numbers, pass_by_reference=[False, True])
+        self._verify_all(numbers, [False, True, True, True])
+
+        # only the odd sets of numbers should change
+        numbers = [list(range(10)) for _ in range(4)]
+        changed = (True, False, True, False)
+        VariablePassing.multipleParamsStatic(*numbers, pass_by_reference=changed)
+        self._verify_all(numbers, changed)
+
+        # only the even sets of numbers should change
+        numbers = [list(range(10)) for _ in range(4)]
+        changed = (False, True, False, True)
+        VariablePassing.multipleParamsStatic(*numbers, pass_by_reference=changed)
+        self._verify_all(numbers, changed)


### PR DESCRIPTION
Here is my pull request for my work so far to improve the `jnius.ByteArray` class with the end goal of making it faster to pass large blocks of raw bytes back and forth between Python and Java.

Raw bytes can be in three forms: the `bytes` type, i.e. `b'123'`, the builtin `bytearray` type, i.e. `bytearray(b'123')`, and the class `jnius.ByteArray`. The `ByteArray` class is created by the jnius library when Java functions have the `byte[]` return type and currently cannot be created adhoc (something like `jnius.jnius.ByteArray(b'123')` will execute but the ByteArray buffer will be empty).

I need to pass blocks of bytes back and forth between Python and Java. Through experimenting I discovered I could pass a `ByteArray` instance back to Java much faster than passing a `bytearray` instance with the same size. I also saw I could fiddle with the `ByteArray` code to make it mutable, providing me with the opportunity to quickly get a `ByteArray`, make the changes I needed, and then pass it back. This works well for my purposes.

The new `__setitem__` method I added to jnius_nativetypes.pxi seems to work but probably has some bugs. Obviously I'll create unittests for this. I'd like to try out different approaches for `__setitem__` and I might as well make improvements to `__getitem__` also while I'm at it.

On discord I was commenting to @tshirtman that merely adding the `__getitem__` method to `ByteArray` hurt performance, even if I wasn't actually using it in my code. This was due to a combination of two problems: first, my `__getitem__` method was slow, and second, the `release_args` function in jnius_conversion.pxi. In `release_args` there's a block of code that does this:

```
            try:
                args[index][:] = ret
            except TypeError:
                pass
```

Before I added the `__getitem__` method, when `ByteArray` objects hit this code the exception would be thrown and no copying would happen. After I added it, the exception would not be thrown and the `__getitem__` method which at the time was slow would be used to recopy the data, huring performance.

I understand what this is for: it is to simulate passing objects by reference. (I figured it out by commenting this out and seeing which unittests broke :) ) Since Python and Java don't share the same memory, objects must be passed by value. To simulate passing by reference, they are copied back after the function completes.

Simulating pass by reference makes sense for most programming situations because it is what programmers would expect. However, in my case of passing large blocks of bytes, it is an extra memory copy that I'd rather avoid. Therefore, I'd like to propose a way to make that second copy optional, either for `ByteArray`s only  or other Java arrays as well. In this PR I added a `_JNIUS_PASS_BY_VALUE` attribute to the `ByteArray` class that the `release_args` function checks for. Although I see that what I wrote doesn't work for anything other than `ByteArray` though, so this needs some work.

This PR is a work in progress but I wanted @tshirtman , @cmacdonald and anyone else to be able to comment on what I've done so far. Also it happens I have surgery tomorrow and will need to be away from my computer for a while, so these notes will be helpful to me when I pick this up again.

Things to do and questions:

* Learn Cython
* Performance test Cython code for the `__getitem__` and `__setitem__` methods to make them as fast as possible
* Should I be adding a `__setitem__` method at all? How about a `replace_data` method instead?
* Any data updating would need to have checks in place to make sure the new data has the right length and probably a bunch of other things
* Should I make similar changes to jnius_nativetypes.pxi (for Python 2.7)?
* Revisit the performance of passing the builtin type `bytearray`. Can it be made to be as fast as `jnius.ByteArray`? Why isn't it as fast?
* Unittests. Lots of unittests.