### PR TITLE
Fix static methods

### DIFF
--- a/tests/test_constructor.py
+++ b/tests/test_constructor.py
@@ -20,7 +20,8 @@ class TestConstructor(unittest.TestCase):
         ConstructorTest = autoclass('org.jnius.ConstructorTest')
         inst = ConstructorTest()
         self.assertEqual(inst.ret, 753)
-        self.assertTrue(ConstructorTest.getClass().isInstance(inst))
+        self.assertTrue(ConstructorTest._class.isInstance(inst))
+        self.assertTrue(inst.getClass().isInstance(inst))
 
     def test_constructor_int(self):
         '''
@@ -30,7 +31,8 @@ class TestConstructor(unittest.TestCase):
         ConstructorTest = autoclass('org.jnius.ConstructorTest')
         inst = ConstructorTest(123)
         self.assertEqual(inst.ret, 123)
-        self.assertTrue(ConstructorTest.getClass().isInstance(inst))
+        self.assertTrue(ConstructorTest._class.isInstance(inst))
+        self.assertTrue(inst.getClass().isInstance(inst))
 
     def test_constructor_string(self):
         '''
@@ -41,8 +43,8 @@ class TestConstructor(unittest.TestCase):
         ConstructorTest = autoclass('org.jnius.ConstructorTest')
         inst = ConstructorTest('a')
         self.assertEqual(inst.ret, ord('a'))
-        self.assertTrue(ConstructorTest.getClass().isInstance(inst))
-
+        self.assertTrue(ConstructorTest._class.isInstance(inst))
+        self.assertTrue(inst.getClass().isInstance(inst))
 
     def test_constructor_multiobj(self):
         '''
@@ -53,7 +55,8 @@ class TestConstructor(unittest.TestCase):
         ConstructorTest = autoclass('org.jnius.ConstructorTest')
         inst = ConstructorTest(outputStream, signature="(Ljava/io/OutputStream;)V")
         self.assertEqual(inst.ret, 42)
-        self.assertTrue(ConstructorTest.getClass().isInstance(inst))
+        self.assertTrue(ConstructorTest._class.isInstance(inst))
+        self.assertTrue(inst.getClass().isInstance(inst))
 
     def test_constructor_int_string(self):
         '''
@@ -64,7 +67,8 @@ class TestConstructor(unittest.TestCase):
         ConstructorTest = autoclass('org.jnius.ConstructorTest')
         inst = ConstructorTest(3, 'a')
         self.assertEqual(inst.ret, 3 + ord('a'))
-        self.assertTrue(ConstructorTest.getClass().isInstance(inst))
+        self.assertTrue(ConstructorTest._class.isInstance(inst))
+        self.assertTrue(inst.getClass().isInstance(inst))
 
     def test_constructor_exception(self):
         '''

--- a/tests/test_static.py
+++ b/tests/test_static.py
@@ -1,0 +1,38 @@
+'''
+Test calling non-static methods on classes.
+'''
+
+from __future__ import absolute_import
+import unittest
+from jnius import autoclass, JavaException, JavaMethod, JavaMultipleMethod
+
+
+class TestStatic(unittest.TestCase):
+
+    def test_method(self):
+        '''
+        Call a non-static JavaMethod on a class,
+        should raise JavaException.
+        '''
+
+        String = autoclass('java.lang.String')
+        self.assertIsInstance(String.replaceAll, JavaMethod)
+        self.assertEqual(String('foo').replaceAll('foo', 'bar'), 'bar')
+        with self.assertRaises(JavaException):
+            String.replaceAll('foo', 'bar')
+
+    def test_multiplemethod(self):
+        '''
+        Call a non-static JavaMultipleMethod on a class,
+        should raise JavaException.
+        '''
+
+        String = autoclass('java.lang.String')
+        self.assertIsInstance(String.toString, JavaMultipleMethod)
+        self.assertEqual(String('baz').toString(), 'baz')
+        with self.assertRaises(JavaException):
+            String.toString()
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Properly fixes the issue found via #538.

This was already partially fixed between 1.2.1 and 1.3.0 because the new class hierarchy walk resulted in more `JavaMultipleMethod`s, which already handled static methods correctly.