### PR TITLE
Add pyproject.toml to specify Cython as a build requirement

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools", "wheel", "Cython"]
+build-backend = "setuptools.build_meta"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,2 @@
 [build-system]
 requires = ["setuptools", "wheel", "Cython"]
-build-backend = "setuptools.build_meta"


### PR DESCRIPTION
This PR adds a pyproject.toml to specify build requirements, most importantly Cython. This means that `pip install`-ing pyjnius will work without Cython having to be pre-installed. I tested this by starting a clean virtualenv and doing `pip install git+https://github.com/bgyori/pyjnius.git@pyproject`, which produces the following output:
```
Collecting git+https://github.com/bgyori/pyjnius.git@pyproject
  Cloning https://github.com/bgyori/pyjnius.git (to revision pyproject) to /private/var/folders/q6/0trkzkfd1pxd6v0675wdzb380000gr/T/pip-req-build-yteli8c8
  Running command git clone -q https://github.com/bgyori/pyjnius.git /private/var/folders/q6/0trkzkfd1pxd6v0675wdzb380000gr/T/pip-req-build-yteli8c8
  Running command git checkout -b pyproject --track origin/pyproject
  Switched to a new branch 'pyproject'
  Branch 'pyproject' set up to track remote branch 'pyproject' from 'origin'.
  Installing build dependencies ... done
  Getting requirements to build wheel ... done
    Preparing wheel metadata ... done
Collecting cython
  Using cached Cython-0.29.23-cp39-cp39-macosx_10_9_x86_64.whl (1.9 MB)
Collecting six>=1.7.0
  Using cached six-1.16.0-py2.py3-none-any.whl (11 kB)
Building wheels for collected packages: pyjnius
  Building wheel for pyjnius (PEP 517) ... done
  Created wheel for pyjnius: filename=pyjnius-1.3.0-cp39-cp39-macosx_10_14_x86_64.whl size=274723 sha256=475241ce07fd2100a478cfad37262c951dec2b07830c5cb536835125403bea84
  Stored in directory: /private/var/folders/q6/0trkzkfd1pxd6v0675wdzb380000gr/T/pip-ephem-wheel-cache-xv3313p8/wheels/8e/90/90/7d7124e211188973f81770a8fcccaf82ebefc0e9b2c92c37bf
Successfully built pyjnius
Installing collected packages: six, cython, pyjnius
Successfully installed cython-0.29.23 pyjnius-1.3.0 six-1.16.0
```