### PR TITLE
Use Python standard library `which` instead of OS `which`

### DIFF
--- a/jnius/env.py
+++ b/jnius/env.py
@@ -16,6 +16,11 @@ log = getLogger(__name__)
 
 PY2 = sys.version_info.major < 3
 
+if PY2:
+    from distutils.spawn import find_executable as which
+else:
+    from shutil import which
+
 machine = machine()  # not expected to change at runtime
 
 # This dictionary converts values from platform.machine()
@@ -102,11 +107,12 @@ def get_jre_home(platform):
         jre_home = join(JAVA_HOME, 'jre')
 
     if platform != 'win32' and not jre_home:
-        jre_home = realpath(
-            check_output(
-                split('which java')
-            ).decode('utf-8').strip()
-        ).replace('bin/java', '')
+        try:
+            jre_home = realpath(
+                which('java')
+            ).replace('bin/java', '')
+        except TypeError:
+            raise Exception('Unable to find java')
 
     if platform == 'win32':
         if isinstance(jre_home, bytes):
@@ -132,11 +138,12 @@ def get_jdk_home(platform):
                 jdk_home = TMP_JDK_HOME
 
         else:
-            jdk_home = realpath(
-                check_output(
-                    ['which', 'javac']
-                ).decode('utf-8').strip()
-            ).replace('bin/javac', '')
+            try:
+                jdk_home = realpath(
+                    which('javac')
+                ).replace('bin/javac', '')
+            except TypeError:
+                raise Exception('Unable to find javac')
 
     if not jdk_home or not exists(jdk_home):
         raise Exception('Unable to determine JDK_HOME')


### PR DESCRIPTION
When `pyjnius` is installed in an environment that doesn't have the `which` command, the two functions `get_jdk_home` and `get_jre_home` might fail if they try to invoke the OS `which` command.

This PR fixes this issue by instead using the `which` implementation in the Python standard library, namely `shutil.which` for Python 3 and `distutils.spawn.find_executable` for Python 2. If the searched executable wasn't found in the original code the setup was failing with an error, so similarly I raised an explanatory exception in those cases.

If the conditional import seems icky, we could:
- Drop the `find_executable` import if you decide to drop Python 2 support, or
- Drop the `shutil.which` import since `find_executable` also works on Python 3, I only kept it because [`shutil.which`](https://github.com/python/cpython/blob/main/Lib/shutil.py#L1381) seems to have some minor improvements over [`find_executable`](https://github.com/python/cpython/blob/main/Lib/distutils/spawn.py#L95) e.g. checking `PATHEXT` for Windows.