### PR TITLE
Use platform.machine() as default get_cpu() return value

### DIFF
--- a/jnius/env.py
+++ b/jnius/env.py
@@ -349,5 +349,5 @@ def get_cpu():
             "WARNING: Not able to assign machine()"
             " = %s to a cpu value!" % machine
         )
-        print("         Using cpu = 'i386' instead!")
-        return 'i386'
+        print(f"         Using cpu = '{machine}' instead!")
+        return machine

--- a/jnius/env.py
+++ b/jnius/env.py
@@ -31,6 +31,7 @@ MACHINE2CPU = {
     "x86_64": "amd64",
     "AMD64": "amd64",
     "armv7l": "arm",
+    "aarch64": "aarch64",
     "sun4u": "sparcv9",
     "sun4v": "sparcv9"
 }


### PR DESCRIPTION
It's much more likely to be correct, eg on aarch64 in my case. :-)