### PR TITLE
 When cross-compiling for Android, we should not use the include dirs exposed by the JDK

### DIFF
--- a/jnius/env.py
+++ b/jnius/env.py
@@ -270,6 +270,12 @@ class AndroidJavaLocation(UnixJavaLocation):
     def get_libraries(self):
         return ['SDL2', 'log']
 
+    def get_include_dirs(self):
+        # When cross-compiling for Android, we should not use the include dirs
+        # exposed by the JDK. Instead, we should use the one exposed by the
+        # Android NDK (which are already handled via python-for-android).
+        return []
+
     def get_library_dirs(self):
         return []
 


### PR DESCRIPTION
When cross-compiling for Android, we should not use the include directories exposed by the JDK as contains platform-specific code (`jni_md.h`).

Instead, we should use the `sysroot` include directories exposed by the Android NDK (`python-for-android` already sets the appropriate `CFLAGS`).

The Android NDK exposes `jni.h` @ `./android-ndk-*/toolchains/llvm/prebuilt/*/sysroot/usr/include/jni.h`

FYI: The issue has been discovered during https://github.com/kivy/python-for-android/pull/2586, as the newer JDK on macOS doesn't include `linux` platform-specific headers, which the android build was expecting.