### PR TITLE
Move get_cpu guessing into _possible_lib_location

### DIFF
--- a/jnius/env.py
+++ b/jnius/env.py
@@ -165,13 +165,9 @@ class JavaLocation:
             )
             return libjvm_override_path
 
-        cpu = get_cpu()
         platform = self.platform
-        log.debug(
-            "looking for libjvm to initiate pyjnius, cpu is %s, platform is %s",
-            cpu, platform
-        )
-        lib_locations = self._possible_lib_locations(cpu)
+        log.debug("looking for libjvm to initiate pyjnius, platform is %s", platform)
+        lib_locations = self._possible_lib_locations()
         for location in lib_locations:
             full_lib_location = join(self.home, location)
             if exists(full_lib_location):
@@ -193,7 +189,7 @@ class JavaLocation:
         % [join(self.home, loc) for loc in lib_locations]
     )
 
-    def _possible_lib_locations(self, cpu):
+    def _possible_lib_locations(self):
         '''
             Returns a list of relative possible locations for the Java library.
             Used by the default implementation of get_jnius_lib_location()
@@ -223,10 +219,15 @@ class UnixJavaLocation(JavaLocation):
         else:
             return join(self.home, 'include', 'linux')
 
-    def _possible_lib_locations(self, cpu):
+    def _possible_lib_locations(self):
         root = self.home
         if root.endswith('jre'):
             root = root[:-3]
+
+        cpu = get_cpu()
+        log.debug(
+            f"Platform {self.platform} may need cpu in path to find libjvm, which is: {cpu}"
+        )
 
         return [
             'lib/server/libjvm.so',
@@ -239,7 +240,7 @@ class MacOsXJavaLocation(UnixJavaLocation):
     def _get_platform_include_dir(self):
         return join(self.home, 'include', 'darwin')
 
-    def _possible_lib_locations(self, cpu):
+    def _possible_lib_locations(self):
         if '1.6' in self.home:
             return ['../Libraries/libjvm.dylib'] # TODO what should this be resolved to?
 


### PR DESCRIPTION
- Not all the platforms need a `cpu` while guessing for `libjvm`
- Adding a mapping in `MACHINE2CPU` for platforms where the cpu doesn't need to be guessed may lead to unexpected bugs in future.
- I noticed it while working on PR #625 , as tests on Apple Silicon are failing due to: 
  ```
   self = <json.decoder.JSONDecoder object at 0x101d05ea0>
    [235](https://github.com/kivy/pyjnius/runs/6739396035?check_suite_focus=true#step:12:236)
    s = 'WARNING: Not able to assign machine() = arm64 to a cpu value!\n         Using cpu = \'arm64\' instead!\n["-Dtest.var0...=value", "-Dtest.var35=value", "-Dtest.var36=value", "-Dtest.var37=value", "-Dtest.var38=value", "-Dtest.var39=value"]'
    [236](https://github.com/kivy/pyjnius/runs/6739396035?check_suite_focus=true#step:12:237)
    idx = 0
   ```
   (basically the test parses what can be found on`stdout` as a json,  but it fails as an unexpected `WARNING` log is also on `stdout` buffer)
   The test may be changed in order to avoid this kind of edge case, but this time worked great to improve our codebase 😄 .