### PR TITLE
Updated java-setup to v3, include all the LTS versions from adoptium during CI tests.

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -17,10 +17,8 @@ jobs:
            - 'pypy-3.9'
         java:
           - '8'
-          # - '9' # commented out just for faster CI
-          # - '10'
-          # - '11' # commented out just for faster CI
-          - '12'
+          - '11'
+          - '17'
         os:
           - 'ubuntu-latest'
           - 'windows-latest'
@@ -56,9 +54,10 @@ jobs:
         architecture: ${{ matrix.architecture }}
 
     - name: Setup java
-      uses: actions/setup-java@v1
+      uses: actions/setup-java@v3
       with:
         java-version: ${{ matrix.java }}
+        distribution: 'temurin'
         architecture: ${{ matrix.architecture }}
 
     - name: install-windows


### PR DESCRIPTION
- Updates `java-setup` to `v3`
- Tests are performed on all the (current and supported) LTS versions.
- Uses `temurin` (aka adoptium) as a JDK "vendor".