### PR TITLE
Cython now requires a minimum version. Introduces setup.cfg. Cleans up the CI workflow

### DIFF
--- a/.github/workflows/push-x86.yml
+++ b/.github/workflows/push-x86.yml
@@ -50,7 +50,6 @@ jobs:
     - name: install
       run: |
         linux32 sh -ec '
-          pip install --timeout=120 -U setuptools cython
           pip install --timeout=120 .[dev,ci]
         '
 

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -22,7 +22,7 @@ jobs:
         os:
           - 'ubuntu-latest'
           - 'windows-latest'
-          - 'macOs-latest'
+          - 'macos-latest'
         architecture:
           - 'x64'
           - 'x86'
@@ -31,7 +31,7 @@ jobs:
         exclude:
         - os: ubuntu-latest
           architecture: 'x86'
-        - os: macOs-latest
+        - os: macos-latest
           architecture: 'x86'
         - os: windows-latest
           architecture: 'x86'
@@ -60,51 +60,30 @@ jobs:
         distribution: 'temurin'
         architecture: ${{ matrix.architecture }}
 
-    - name: install-windows
-      if: matrix.os == 'windows-latest'
-      run: |
-        "%VS140COMNTOOLS%../../VC/vcvarsall.bat"
-        echo "$INCLUDE"
-        set INCLUDE "C:/Program Files (x86)/Windows Kits/10/Include/10.0.10240.0/ucrt"
-        pip install --timeout=120 -U setuptools cython
-        pip install --timeout=120 -vv .[dev,ci]
+    - name: (macOS) Setup test dependencies
+      if: matrix.os == 'macos-latest'
+      run: brew install ant
 
-    - name: install
-      if: matrix.os == 'ubuntu-latest'
+    - name: Build test classes via ant
+      run: ant all
+
+    - name: Install pyjnius with [dev, ci] extras
       run: |
-        pip install --timeout=120 -U setuptools cython
         pip install --timeout=120 .[dev,ci]
-
-    - name: install-osx
-      if: matrix.os == 'macOs-latest'
-      run: |
-        brew install ant
-        pip install --timeout=120 --user -U setuptools cython
-        pip install --timeout=120 --user .[dev,ci]
-
-    - name: test-windows
+  
+    - name: (Windows) Test pyjnius via pytest
       if: matrix.os == 'windows-latest'
       run: |
         $env:PATH +=";$env:JAVA_HOME\jre\bin\server\;$env:JAVA_HOME\jre\bin\client\;$env:JAVA_HOME\bin\server\"
         $env:CLASSPATH ="../build/test-classes;../build/classes"
-
-        ant all
         cd tests
         pytest -v
 
-    - name: test
-      if: matrix.os == 'ubuntu-latest'
+    - name: (Linux, macOS) Test pyjnius via pytest
+      if: (matrix.os == 'ubuntu-latest') || (matrix.os == 'macos-latest')
       run: |
-        ant all
         cd tests
-        CLASSPATH=../build/test-classes:../build/classes pytest -v
-
-    - name: test
-      if: matrix.os == 'macOs-latest'
-      run: |
-        ant all
-        cd tests
-          CLASSPATH=../build/test-classes:../build/classes python -m pytest -v
+        CLASSPATH=../build/test-classes:../build/classes python -m pytest -v
 
 #     - name: coveralls
 #       run: python -m coveralls

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,2 +1,6 @@
 [build-system]
-requires = ["setuptools", "wheel", "Cython"]
+requires = [
+    "setuptools>=58.0.0",
+    "wheel",
+    "Cython>=0.29.30"
+]

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,12 @@
+[options]
+install_requires =
+    six>=1.7.0
+
+[options.extras_require]
+dev =
+    pytest
+    pytest-cov
+    pycodestyle
+ci =
+    coveralls
+    pytest-rerunfailures

--- a/setup.py
+++ b/setup.py
@@ -11,10 +11,8 @@ except ImportError:
     import subprocess
 
 from os import environ
-from os.path import dirname, join, exists
-import re
+from os.path import dirname, join
 import sys
-from platform import machine
 from setup_sdist import SETUP_KWARGS
 
 # XXX hack to be able to import jnius.env withough having build
@@ -56,8 +54,6 @@ FILES = [
 ]
 
 EXTRA_LINK_ARGS = []
-INSTALL_REQUIRES = ['six>=1.7.0']
-SETUP_REQUIRES = []
 
 # detect Python for android
 PLATFORM = sys.platform
@@ -65,10 +61,8 @@ NDKPLATFORM = getenv('NDKPLATFORM')
 if NDKPLATFORM is not None and getenv('LIBLINK'):
     PLATFORM = 'android'
 
-# detect cython
-if PLATFORM != 'android':
-    SETUP_REQUIRES.append('cython')
-else:
+# detect platform
+if PLATFORM == 'android':
     FILES = [fn[:-3] + 'c' for fn in FILES if fn.endswith('pyx')]
 
 JAVA=get_java_setup(PLATFORM)
@@ -118,12 +112,6 @@ for ext_mod in ext_modules:
 # create the extension
 setup(
     cmdclass={'build_ext': build_ext},
-    install_requires=INSTALL_REQUIRES,
-    setup_requires=SETUP_REQUIRES,
     ext_modules=ext_modules,
-    extras_require={
-        'dev': ['pytest', 'wheel', 'pytest-cov', 'pycodestyle'],
-        'ci': ['coveralls', 'pytest-rerunfailures', 'setuptools>=34.4.0'],
-    },
     **SETUP_KWARGS
 )


### PR DESCRIPTION
- As suggested by @tshirtman in #627 we now require a minimum `Cython` version.
- Build-time dependencies are now completely managed via `pyproject.toml`
- extras are now described in `setup.cfg`
- Install-time requirements are now described in `setup.cfg`
- Removed some unused variables in `setup.py`
- The CI workflow has been cleaned up from duplicates, and build-time dependencies are not installed anymore as are already handled via `pip` in an isolated build environment.
- The CD workflow has NOT been updated yet to reflect the changes, as will be targeted during #625 