### PR TITLE
Initialize logger as a child of the Kivy's one

### DIFF
--- a/jnius/env.py
+++ b/jnius/env.py
@@ -9,11 +9,11 @@ from os import getenv
 from platform import machine
 from subprocess import Popen, check_output, PIPE
 from shlex import split
-from logging import getLogger
+import logging
 from textwrap import dedent
 from shutil import which
 
-log = getLogger(__name__)
+log = logging.getLogger('kivy').getChild(__name__)
 
 machine = machine()  # not expected to change at runtime
 

--- a/jnius/reflect.py
+++ b/jnius/reflect.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import
 from __future__ import unicode_literals
 from __future__ import division
 from collections import defaultdict
-from logging import getLogger, DEBUG
+import logging
 
 
 from .jnius import (
@@ -13,7 +13,7 @@ from .jnius import (
 
 __all__ = ('autoclass', 'ensureclass', 'protocol_map')
 
-log = getLogger(__name__)
+log = logging.getLogger('kivy').getChild(__name__)
 
 
 class Class(JavaClass, metaclass=MetaJavaClass):
@@ -298,7 +298,7 @@ def autoclass(clsname, include_protected=True, include_private=True):
             sig = '({0}){1}'.format(
                 ''.join([get_signature(x) for x in method.getParameterTypes()]),
                 get_signature(method.getReturnType()))
-            if log.isEnabledFor(DEBUG):
+            if log.isEnabledFor(logging.DEBUG):
                 log_method(method, name, sig)
             classDict[name] = (JavaStaticMethod if static else JavaMethod)(sig, varargs=varargs)
             # methods that fit the characteristics of a JavaBean's methods get turned into properties.
@@ -333,7 +333,7 @@ def autoclass(clsname, include_protected=True, include_private=True):
                 return_sig = get_signature(method.getReturnType())
                 sig = '({0}){1}'.format(param_sig, return_sig)
 
-                if log.isEnabledFor(DEBUG):
+                if log.isEnabledFor(logging.DEBUG):
                     log_method(method, name, sig)
                 signatures.append((sig, Modifier.isStatic(method.getModifiers()), method.isVarArgs()))
 


### PR DESCRIPTION
## Preface
Kivy's logging has been recently improved via:
- https://github.com/kivy/kivy/pull/7988
- https://github.com/kivy/kivy/pull/7979
.. and more minor fixes + tests

When Kivy is in `KIVY_LOG_MODE=KIVY` (which is the default), the root logger level is set to `logging.root.setLevel(logging.NOTSET)`, leaving the sub-loggers (and the Kivy logger) the ability to be the limiting factor.

With the root logger set to `NOTSET`, `pyjnius` started to send debug messages, even if the Kivy logger is set to silence `debug` messages.

This is something expected for third-party libraries and `KIVY_LOG_MODE=MIXED` should be used instead, as explained here: https://kivy.org/doc/master/api-kivy.logger.html#mixed-mode.

## Considerations

`pyjnius` is usable even outside of a Kivy project, but is still part of the Kivy ecosystem, and IMHO should log as Kivy does.

By using a child logger of the Kivy main logger, if the Kivy logger is set to hide `debug` messages, also the log messages from `pyjnius` will be filtered.

From https://docs.python.org/3/library/logging.html#logging.Logger.setLevel: 
> When a logger is created, the level is set to NOTSET (which causes all messages to be processed when the logger is the root logger, or delegation to the parent when the logger is a non-root logger). Note that the root logger is created with level WARNING.
The term ‘delegation to the parent’ means that if a logger has a level of NOTSET, its chain of ancestor loggers is traversed until either an ancestor with a level other than NOTSET is found, or the root is reached.
If an ancestor is found with a level other than NOTSET, then that ancestor’s level is treated as the effective level of the logger where the ancestor search began, and is used to determine how a logging event is handled.
If the root is reached, and it has a level of NOTSET, then all messages will be processed. Otherwise, the root’s level will be used as the effective level.

Nothing changes when `pyjnius` is used in a non-kivy project (except that the logger name now have the `kivy` prefix).

👉  In order to make it fully compatible with the Kivy logger, `pyjnius` will also need to follow the `colon` separation logic, and will be nice to have an option to "mute" the `pyjnius` logger, directly from the Kivy configuration. (I'm scheduling it for Kivy 2.2.0)

FYI:
Everything started from issue: https://github.com/kivy/python-for-android/issues/2704