### PR TITLE
Build (and test) `manylinux-aarch64` wheels via our `kivy-ubuntu-arm64` self-hosted runner [build wheel]

### DIFF
--- a/.ci/utils.sh
+++ b/.ci/utils.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+set -e -x
+
+ensure_python_version(){
+    # This function ensures that the correct python version is selected.
+    # It takes one argument, the python version to use.
+
+    # On github-hosted runners, we use the setup-python action to install the correct python version,
+    # so we don't need to do anything.
+
+    python_version="$1"
+    # if KIVY_SELF_HOSTED_USE_PYENV is set to 1, we use pyenv to select the python version
+    if [[ "$KIVY_SELF_HOSTED_USE_PYENV" == "1" ]]; then
+        source ~/.bashrc
+        pyenv global $python_version
+    fi
+}

--- a/.github/workflows/create.yml
+++ b/.github/workflows/create.yml
@@ -10,41 +10,37 @@ jobs:
     if: (github.event_name == 'create' && github.event.ref_type == 'tag') || contains(github.event.head_commit.message, '[build wheel]') || contains(github.event.pull_request.title, '[build wheel]')
     env:
       CIBW_BEFORE_ALL_LINUX: 'yum install -y java-11-openjdk-devel'
-      CIBW_ARCHS_MACOS: "x86_64 universal2"
       CIBW_REPAIR_WHEEL_COMMAND_MACOS: ''
+      CIBW_SKIP: 'cp36-* *musllinux*'
     strategy:
       matrix:
-        os: ['windows-latest', 'macos-latest']
-        architecture: ['x64']
         include:
           - os: windows-latest
             architecture: 'x86'
-            cibw_skip: '*_amd64'
+            cibw_archs: 'x86'
           - os: windows-latest
             architecture: 'x64'
-            cibw_skip: '*-win32'
+            cibw_archs: 'AMD64'
           - os: ubuntu-latest
             architecture: 'x64'
             cibw_archs: 'x86_64'
-          - os: ubuntu-latest
+          - os: kivy-ubuntu-arm64
             architecture: 'aarch64'
             cibw_archs: aarch64
+          - os: macos-latest
+            architecture: 'x64'
+            cibw_archs: 'x86_64 universal2'
     runs-on: ${{ matrix.os }}
     steps:
-      - name: Set up QEMU for aarch64 wheels
-        if: ${{ matrix.cibw_archs == 'aarch64' }}
-        uses: docker/setup-qemu-action@v1
-        with:
-          platforms: arm64
 
       - name: Checkout pyjnius
         uses: actions/checkout@v3
 
-      - name: Setup Python
-        uses: actions/setup-python@v3
-
-      - name: Install cibuildwheel
-        run: python -m pip install cibuildwheel==2.6.0
+      - name: Setup Python (Ubuntu x86_64, macOS Intel, Windows x86_64)
+        if: matrix.os == 'macos-latest' || matrix.os == 'windows-latest' || matrix.os == 'ubuntu-latest'
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
 
       - name: Setup java
         # There's no need to setup java on ubuntu-latest, as build is done into a manylinux
@@ -56,22 +52,23 @@ jobs:
           distribution: 'temurin'
           architecture: ${{ matrix.architecture }}
 
-      - name: Build Windows and MacOS wheels
-        if: ${{ matrix.os != 'ubuntu-latest' }}
+      - name: Install cibuildwheel & build wheels (Windows)
+        if: matrix.os == 'windows-latest'
         env:
-          CIBW_SKIP: '*musllinux* ${{ matrix.cibw_skip }}'
-        run: python -m cibuildwheel --output-dir dist
-
-      - name: Build and test Linux wheels
-        if: ${{ matrix.os == 'ubuntu-latest' }}
-        env:
-          CIBW_SKIP: '*musllinux* ${{ matrix.cibw_skip }}'
           CIBW_ARCHS: '${{ matrix.cibw_archs }}'
-          CIBW_TEST_REQUIRES: 'pytest'
-          CIBW_TEST_EXTRAS: 'dev,ci'
-          CIBW_BEFORE_TEST: 'yum install ant -y && cd {project} && ant all'
-          CIBW_TEST_COMMAND: 'cd {project}/tests/ && CLASSPATH=../build/test-classes:../build/classes python -m pytest -v'
-        run: python -m cibuildwheel --output-dir dist
+        run: |
+          python -m pip install cibuildwheel==2.6.0
+          python -m cibuildwheel --output-dir dist
+
+      - name: Install cibuildwheel & build wheels (Linux, macOS Intel)
+        if: (matrix.os == 'ubuntu-latest') || (matrix.os == 'kivy-ubuntu-arm64') ||  (matrix.os == 'macos-latest')
+        env:
+          CIBW_ARCHS: '${{ matrix.cibw_archs }}'
+        run: |
+          source .ci/utils.sh
+          ensure_python_version 3.10
+          python -m pip install cibuildwheel==2.6.0
+          python -m cibuildwheel --output-dir dist
 
       - name: upload wheels
         uses: actions/upload-artifact@v2
@@ -88,7 +85,9 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Setup Python
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
 
       - name: Build sdist
         run: |
@@ -109,10 +108,14 @@ jobs:
     continue-on-error: true
     strategy:
       matrix:
-        os: ['macos-latest', 'windows-latest']
-        python: ['3.7', '3.8', '3.9', '3.10', 'pypy-3.7', 'pypy-3.8', 'pypy-3.9']
+        os: ['ubuntu-latest', 'macos-latest', 'windows-latest', 'kivy-ubuntu-arm64']
+        python: ['3.7', '3.8', '3.9', '3.10', 'pypy3.7', 'pypy3.8', 'pypy3.9']
         include:
           # We may would like to introduce tests also on windows-latest on x86 (win32 wheels)?
+          - os: ubuntu-latest
+            architecture: 'x64'
+          - os: kivy-ubuntu-arm64
+            architecture: 'aarch64'
           - os: windows-latest
             architecture: 'x64'
           - os: macos-latest
@@ -128,6 +131,7 @@ jobs:
             python: '3.10.3'
     runs-on: ${{ matrix.os }}
     steps:
+
       - name: Checkout pyjnius
         uses: actions/checkout@v3
 
@@ -136,10 +140,10 @@ jobs:
           name: dist
           path: dist
 
-      - name: Setup Python
+      - name: Setup Python (Ubuntu x86_64, macOS Intel, Windows x86_64)
         # Needs to be skipped on our self-hosted runners tagged as 'apple-silicon-m1'
-        if: ${{ matrix.os  != 'apple-silicon-m1' }}
-        uses: actions/setup-python@v3
+        if: matrix.os == 'macos-latest' || matrix.os == 'windows-latest' || matrix.os == 'ubuntu-latest'
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python }}
 
@@ -157,6 +161,11 @@ jobs:
           arm64_set_path_and_python_version ${{ matrix.python }}
           brew install ant
 
+      - name: Setup ant on Linux
+        if: (matrix.os == 'ubuntu-latest') || (matrix.os == 'kivy-ubuntu-arm64')
+        run: |
+          sudo apt-get update && sudo apt-get install -y ant
+
       - name: Build test-classes via ant (macOS x64, macOS Apple Silicon)
         if: (matrix.os == 'macos-latest') || (matrix.os == 'apple-silicon-m1')
         run: |
@@ -164,13 +173,20 @@ jobs:
           arm64_set_path_and_python_version ${{ matrix.python }}
           ant all
 
-      - name: Build test-classes via ant (Windows)
-        if: matrix.os == 'windows-latest'
+      - name: Build test-classes via ant (Linux, Windows)
+        if: matrix.os == 'windows-latest' || matrix.os == 'kivy-ubuntu-arm64' || matrix.os == 'ubuntu-latest'
         run: ant all
 
       - name: Install pyjnius wheel + test prerequisites (Windows, macOS x64)
-        if: matrix.os != 'apple-silicon-m1'
+        if: matrix.os == 'windows-latest' || matrix.os == 'macos-latest'
         run: python -m pip install --find-links=dist pyjnius[dev,ci]
+
+      - name: Install pyjnius wheel + test prerequisites (Linux)
+        if: matrix.os == 'ubuntu-latest' || matrix.os == 'kivy-ubuntu-arm64'
+        run: |
+          source .ci/utils.sh
+          ensure_python_version ${{ matrix.python }}
+          python -m pip install --find-links=dist pyjnius[dev,ci]
 
       - name: Install pyjnius wheel + test prerequisites (Apple Silicon M1)
         if: matrix.os == 'apple-silicon-m1'
@@ -179,9 +195,11 @@ jobs:
           arm64_set_path_and_python_version ${{ matrix.python }}
           python -m pip install --find-links=dist pyjnius[dev,ci]
 
-      - name: Test wheel (macOS x64)
-        if: matrix.os == 'macos-latest'
+      - name: Test wheel (Linux, macOS Intel)
+        if: (matrix.os == 'ubuntu-latest') || (matrix.os == 'kivy-ubuntu-arm64') || (matrix.os == 'macos-latest')
         run: |
+          source .ci/utils.sh
+          ensure_python_version ${{ matrix.python }}
           cd tests
           CLASSPATH=../build/test-classes:../build/classes python -m pytest -v
 

--- a/.github/workflows/create.yml
+++ b/.github/workflows/create.yml
@@ -14,7 +14,7 @@ jobs:
       CIBW_REPAIR_WHEEL_COMMAND_MACOS: ''
     strategy:
       matrix:
-        os: ['ubuntu-latest', 'windows-latest', 'macos-latest']
+        os: ['windows-latest', 'macos-latest']
         architecture: ['x64']
         include:
           - os: windows-latest
@@ -25,9 +25,18 @@ jobs:
             cibw_skip: '*-win32'
           - os: ubuntu-latest
             architecture: 'x64'
-            cibw_skip: '*-manylinux_i686'
+            cibw_archs: 'x86_64'
+          - os: ubuntu-latest
+            architecture: 'aarch64'
+            cibw_archs: aarch64
     runs-on: ${{ matrix.os }}
     steps:
+      - name: Set up QEMU for aarch64 wheels
+        if: ${{ matrix.cibw_archs == 'aarch64' }}
+        uses: docker/setup-qemu-action@v1
+        with:
+          platforms: arm64
+
       - name: Checkout pyjnius
         uses: actions/checkout@v3
 
@@ -47,9 +56,21 @@ jobs:
           distribution: 'temurin'
           architecture: ${{ matrix.architecture }}
 
-      - name: Build wheels
+      - name: Build Windows and MacOS wheels
+        if: ${{ matrix.os != 'ubuntu-latest' }}
         env:
           CIBW_SKIP: '*musllinux* ${{ matrix.cibw_skip }}'
+        run: python -m cibuildwheel --output-dir dist
+
+      - name: Build and test Linux wheels
+        if: ${{ matrix.os == 'ubuntu-latest' }}
+        env:
+          CIBW_SKIP: '*musllinux* ${{ matrix.cibw_skip }}'
+          CIBW_ARCHS: '${{ matrix.cibw_archs }}'
+          CIBW_TEST_REQUIRES: 'pytest'
+          CIBW_TEST_EXTRAS: 'dev,ci'
+          CIBW_BEFORE_TEST: 'yum install ant -y && cd {project} && ant all'
+          CIBW_TEST_COMMAND: 'cd {project}/tests/ && CLASSPATH=../build/test-classes:../build/classes python -m pytest -v'
         run: python -m cibuildwheel --output-dir dist
 
       - name: upload wheels
@@ -88,15 +109,13 @@ jobs:
     continue-on-error: true
     strategy:
       matrix:
-        os: ['ubuntu-latest', 'macos-latest', 'windows-latest']
+        os: ['macos-latest', 'windows-latest']
         python: ['3.7', '3.8', '3.9', '3.10', 'pypy-3.7', 'pypy-3.8', 'pypy-3.9']
         include:
           # We may would like to introduce tests also on windows-latest on x86 (win32 wheels)?
           - os: windows-latest
             architecture: 'x64'
           - os: macos-latest
-            architecture: 'x64'
-          - os: ubuntu-latest
             architecture: 'x64'
           - os: apple-silicon-m1
             architecture: 'aarch64'
@@ -145,11 +164,11 @@ jobs:
           arm64_set_path_and_python_version ${{ matrix.python }}
           ant all
 
-      - name: Build test-classes via ant (Linux, Windows)
-        if: (matrix.os == 'ubuntu-latest') || (matrix.os == 'windows-latest')
+      - name: Build test-classes via ant (Windows)
+        if: matrix.os == 'windows-latest'
         run: ant all
 
-      - name: Install pyjnius wheel + test prerequisites (Windows, Linux, macOS x64)
+      - name: Install pyjnius wheel + test prerequisites (Windows, macOS x64)
         if: matrix.os != 'apple-silicon-m1'
         run: python -m pip install --find-links=dist pyjnius[dev,ci]
 
@@ -160,8 +179,8 @@ jobs:
           arm64_set_path_and_python_version ${{ matrix.python }}
           python -m pip install --find-links=dist pyjnius[dev,ci]
 
-      - name: Test wheel (Linux, macOS x64)
-        if: (matrix.os == 'ubuntu-latest') || (matrix.os == 'macos-latest')
+      - name: Test wheel (macOS x64)
+        if: matrix.os == 'macos-latest'
         run: |
           cd tests
           CLASSPATH=../build/test-classes:../build/classes python -m pytest -v

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -47,7 +47,7 @@ jobs:
     - uses: actions/checkout@master
 
     - name: Setup python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python }}
         architecture: ${{ matrix.architecture }}


### PR DESCRIPTION
Follow up of #639 , but uses our self-hosted `kivy-ubuntu-arm64` runner for builds and tests.