### PR TITLE
Remove Python `3.6` from supported and test matrix, as it reached EOL

### DIFF
--- a/.github/workflows/push-x86.yml
+++ b/.github/workflows/push-x86.yml
@@ -7,7 +7,6 @@ jobs:
     strategy:
       matrix:
         python:
-           - '3.6'
            - '3.7'
            - '3.8'
            - '3.9'

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -7,7 +7,6 @@ jobs:
     strategy:
       matrix:
         python:
-           - '3.6'
            - '3.7'
            - '3.8'
            - '3.9'

--- a/setup_sdist.py
+++ b/setup_sdist.py
@@ -48,7 +48,6 @@ SETUP_KWARGS = {
         'Operating System :: Microsoft :: Windows',
         'Operating System :: POSIX :: Linux',
         'Operating System :: Android',
-        'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',


### PR DESCRIPTION
- Python `3.6` reached EOL on 23 Dec 2021.
- Tests on Python `3.6` are failing, as `3.6` is not available anymore on github-hosted runners.
```
2023-05-07T07:16:08.1535989Z ##[group]Run actions/setup-python@v2
2023-05-07T07:16:08.1536227Z with:
2023-05-07T07:16:08.1536437Z   python-version: 3.6
2023-05-07T07:16:08.1536655Z   architecture: x64
2023-05-07T07:16:08.1536998Z   token: ***
2023-05-07T07:16:08.1537177Z ##[endgroup]
2023-05-07T07:16:08.4702772Z Version 3.6 was not found in the local cache
2023-05-07T07:16:09.2421893Z ##[error]Version 3.6 with arch x64 not found
```