### PR TITLE
Linux x86 tests force as safe directory

### DIFF
--- a/.github/workflows/push-x86.yml
+++ b/.github/workflows/push-x86.yml
@@ -27,6 +27,7 @@ jobs:
     - name: checkout
       run: |
         linux32 sh -ec '
+          git config --global --add safe.directory '*'
           git init .
           git remote add origin https://github.com/$GITHUB_REPOSITORY
           git config --local gc.auto 0


### PR DESCRIPTION
On [Continuous Integration (x86)](https://github.com/kivy/pyjnius/actions/workflows/push-x86.yml) tests, it started complaining about `fatal: detected dubious ownership in repository at '/__w/pyjnius/pyjnius'`.

This is due to permission issues, related to how we call the tests in order to be performed on a 32 bit environment.