### PR TITLE
Add support request automation (as other kivy projects)

### DIFF
--- a/.github/workflows/support.yml
+++ b/.github/workflows/support.yml
@@ -1,0 +1,27 @@
+name: 'Support Requests'
+
+on:
+  issues:
+    types: [labeled, unlabeled, reopened]
+
+permissions:
+  issues: write
+
+jobs:
+  action:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: dessant/support-requests@v2
+        with:
+          github-token: ${{ github.token }}
+          support-label: 'support'
+          issue-comment: >
+            👋 We use the issue tracker exclusively for bug reports and feature requests.
+            However, this issue appears to be a support request. Please use our
+            [support channels](https://github.com/kivy/pyjnius/blob/master/README.md#support)
+            to get help with the project.
+
+            Let us know if this comment was made in error, and we'll be happy
+            to reopen the issue.
+          close-issue: true
+          lock-issue: false


### PR DESCRIPTION
As `kivy/kivy` (and many others `kivy` projects), now also `pyjnius` have the `support` label automation.