### PR TITLE
introduce protocol_map for Map$Entry

### DIFF
--- a/jnius/reflect.py
+++ b/jnius/reflect.py
@@ -377,6 +377,12 @@ def _map_getitem(self, k):
         raise KeyError()
     return rtr
 
+def _map_entry_getitem(self, i):
+    if i == 0:
+        return self.getKey()
+    if i == 1:
+        return self.getValue()
+    raise IndexError()
 
 def _iterator_next(self):
     ''' dunder method for java.util.Iterator'''
@@ -403,6 +409,11 @@ protocol_map = {
         '__len__' : lambda self: self.size(),
         '__contains__' : lambda self, item: self.containsKey(item),
         '__iter__' : lambda self: self.keySet().iterator()
+    },
+    'java.util.Map$Entry' : {
+        '__getitem__' : _map_entry_getitem,
+        '__iter__' : lambda self: iter([self.getKey(), self.getValue()]),
+        '__len__' : lambda self: 2
     },
     'java.util.Iterator' : {
         '__iter__' : lambda self: self,

--- a/tests/test_collections.py
+++ b/tests/test_collections.py
@@ -41,6 +41,9 @@ class TestCollections(unittest.TestCase):
         # __iter__
         for k in hmap:
            self.assertTrue(k in data)
+        # __map_entry__
+        for k,v in hmap.entrySet():
+           self.assertEqual(data[k], v)
         # __contains__
         self.assertFalse(0 in hmap)
         # __delitem__


### PR DESCRIPTION
Please consider this simple PR which allows a Map$Entry to behave like a tuple in Python.

```python
map = autoclass("java.util.HashMap")()
map.put("a", "b")
for k,v in map.entrySet():
  print(k,v)
```