### PR TITLE
Force cython 2.x

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -70,6 +70,7 @@ jobs:
     - name: Install pyjnius with [dev, ci] extras
       run: |
         pip install --timeout=120 .[dev,ci]
+        pip list
   
     - name: (Windows) Test pyjnius via pytest
       if: matrix.os == 'windows-latest'

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -70,7 +70,6 @@ jobs:
     - name: Install pyjnius with [dev, ci] extras
       run: |
         pip install --timeout=120 .[dev,ci]
-        pip list
   
     - name: (Windows) Test pyjnius via pytest
       if: matrix.os == 'windows-latest'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,5 +2,5 @@
 requires = [
     "setuptools>=58.0.0",
     "wheel",
-    "Cython>=0.29.30"
+    "Cython>=0.29.30,<3"
 ]

--- a/setup.py
+++ b/setup.py
@@ -33,8 +33,22 @@ def getenv(key):
     return val
 
 
-FILES = [
+PYX_FILES = [
     'jnius.pyx',
+]
+PXI_FILES = [
+    'jnius_compat.pxi',
+    'jnius_conversion.pxi',
+    'jnius_export_class.pxi',
+    'jnius_export_func.pxi',
+    'jnius_jvm_android.pxi',
+    'jnius_jvm_desktop.pxi',
+    'jnius_jvm_dlopen.pxi',
+    'jnius_localref.pxi',
+    'jnius_nativetypes3.pxi',
+    'jnius_proxy.pxi',
+    'jnius.pyx',
+    'jnius_utils.pxi'
 ]
 
 EXTRA_LINK_ARGS = []
@@ -47,7 +61,7 @@ if NDKPLATFORM is not None and getenv('LIBLINK'):
 
 # detect platform
 if PLATFORM == 'android':
-    FILES = [fn[:-3] + 'c' for fn in FILES if fn.endswith('pyx')]
+    PYX_FILES = [fn[:-3] + 'c' for fn in PYX_FILES]
 
 JAVA=get_java_setup(PLATFORM)
 
@@ -80,7 +94,9 @@ SETUP_KWARGS['py_modules'].remove('setup')
 
 ext_modules = [
     Extension(
-        'jnius', [join('jnius', x) for x in FILES],
+        'jnius', 
+        [join('jnius', x) for x in PYX_FILES],
+        depends=[join('jnius', x) for x in PXI_FILES],
         libraries=JAVA.get_libraries(),
         library_dirs=JAVA.get_library_dirs(),
         include_dirs=JAVA.get_include_dirs(),

--- a/setup.py
+++ b/setup.py
@@ -34,19 +34,7 @@ def getenv(key):
 
 
 FILES = [
-    'jni.pxi',
-    'jnius_compat.pxi',
-    'jnius_conversion.pxi',
-    'jnius_export_class.pxi',
-    'jnius_export_func.pxi',
-    'jnius_jvm_android.pxi',
-    'jnius_jvm_desktop.pxi',
-    'jnius_jvm_dlopen.pxi',
-    'jnius_localref.pxi',
-    'jnius_nativetypes3.pxi',
-    'jnius_proxy.pxi',
     'jnius.pyx',
-    'jnius_utils.pxi',
 ]
 
 EXTRA_LINK_ARGS = []


### PR DESCRIPTION
As noted in #663, Jnius does not build currently. This is because of the release last month of Cython 3.0.

There are two issues:
(1) Cython 3.0 wont compile include files (.pxi). I have excluded these
(2) Jnius compiled using Cython 3.0 fails with `AttributeError: 'Class' object has no attribute '_JavaClass__cls_storage'`. I cant easily see why this is occurring.

I think we should do a new 1.5.1 release as soon as possible using this PR, as anyone installing Jnius in an environment without prebuilt binaries will currently not succeed. Pegging to Cython <3.0 will address the main problem for now. We can create another issue for Cython 3 support.