### PR TITLE
Support Java 20, remove Java 7 support

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -45,6 +45,8 @@ jobs:
         - os: windows-latest
           architecture: 'x86'
           python: 'pypy-3.9'
+        - os: windows-latest
+          java: '20'
 
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -18,7 +18,7 @@ jobs:
         java:
           - '8'
           - '11'
-          - '17'
+          - '20'
         os:
           - 'ubuntu-latest'
           - 'windows-latest'

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -60,7 +60,7 @@ jobs:
       uses: actions/setup-java@v3
       with:
         java-version: ${{ matrix.java }}
-        distribution: 'temurin'
+        distribution: 'zulu'
         architecture: ${{ matrix.architecture }}
 
     - name: (macOS) Setup test dependencies

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -46,6 +46,7 @@ jobs:
           architecture: 'x86'
           python: 'pypy-3.9'
         - os: windows-latest
+          architecture: 'x86'
           java: '20'
 
     runs-on: ${{ matrix.os }}
@@ -62,7 +63,7 @@ jobs:
       uses: actions/setup-java@v3
       with:
         java-version: ${{ matrix.java }}
-        distribution: 'zulu'
+        distribution: 'temurin'
         architecture: ${{ matrix.architecture }}
 
     - name: (macOS) Setup test dependencies

--- a/build.xml
+++ b/build.xml
@@ -1,6 +1,6 @@
 <project>
-    <property name="ant.build.javac.source" value="1.7" />
-    <property name="ant.build.javac.target" value="1.7" />
+    <property name="ant.build.javac.source" value="8" />
+    <property name="ant.build.javac.target" value="8" />
 
     <target name="clean">
       <delete dir="build/classes"/>

--- a/setup.py
+++ b/setup.py
@@ -70,7 +70,7 @@ assert JAVA.is_jdk(), "You need a JDK, we only found a JRE. Try setting JAVA_HOM
 def compile_native_invocation_handler(java):
     '''Find javac and compile NativeInvocationHandler.java.'''
     javac = java.get_javac()
-    source_level = '1.7'
+    source_level = '8'
     try:
         subprocess.check_call([
             javac, '-target', source_level, '-source', source_level,


### PR DESCRIPTION
Java 20 (released in March 2023) has removed support for compiling class files for JDK 7. This means Jnius doesn’t currently compile (nor run?) under Java 20.

Java SE 7 had End of Extended Support in July 2022. So we need no longer support Java 7 as a target.

Please consider this PR for 1.6.0 release cycle that
- supports and tests Java 20 in GHA
- Removes Java 7 as the target

NB: I had to change the Java distribution in GHA to one that had Java 20 on most platforms.