### PR TITLE
Remove pkg_resources for Python >=3.9

### DIFF
--- a/.github/workflows/push-x86.yml
+++ b/.github/workflows/push-x86.yml
@@ -59,5 +59,5 @@ jobs:
         linux32 sh -ec '
           ant all
           cd tests
-          CLASSPATH=../build/test-classes:../build/classes pytest -v -s
+          CLASSPATH=../build/test-classes:../build/classes pytest -v
         '

--- a/.github/workflows/push-x86.yml
+++ b/.github/workflows/push-x86.yml
@@ -59,5 +59,5 @@ jobs:
         linux32 sh -ec '
           ant all
           cd tests
-          CLASSPATH=../build/test-classes:../build/classes pytest -v
+          CLASSPATH=../build/test-classes:../build/classes pytest -v -s
         '

--- a/jnius_config.py
+++ b/jnius_config.py
@@ -79,7 +79,9 @@ def get_classpath():
         atexit.register(file_manager.close)
         # importlib.resources.files is only available from Python 3.9
         # use https://github.com/python/importlib_resources/issues/60 not __name__ as jnius_config.py is not a package
-        return_classpath = [ importlib.resources.files('jnius') / 'src' ]
+        resource_paths = importlib.resources.files('jnius') / 'src'
+        return_classpath = [ p.abspath() for p in resource_paths ]
+        print(return_classpath)
         path = file_manager.enter_context(
             importlib.resources.as_file(return_classpath[0]))
     else:

--- a/jnius_config.py
+++ b/jnius_config.py
@@ -72,7 +72,8 @@ def get_classpath():
     # add a path to java classes packaged with jnius
     if sys.version_info >= (3, 9):
         from contextlib import ExitStack
-        import importlib.resources, atexit
+        import importlib.resources
+        import atexit
 
         # see https://importlib-resources.readthedocs.io/en/latest/migration.html#pkg-resources-resource-filename
         file_manager = ExitStack()
@@ -81,8 +82,7 @@ def get_classpath():
         # use https://github.com/python/importlib_resources/issues/60 not __name__ as jnius_config.py is not a package
         resource_path = importlib.resources.files('jnius') / 'src'
         return_classpath = [ str(resource_path) ]
-        path = file_manager.enter_context(
-            importlib.resources.as_file(resource_path))
+        file_manager.enter_context(importlib.resources.as_file(resource_path))
     else:
         from pkg_resources import resource_filename
         return_classpath = [realpath(resource_filename(__name__, 'jnius/src'))]

--- a/jnius_config.py
+++ b/jnius_config.py
@@ -81,13 +81,11 @@ def get_classpath():
         # use https://github.com/python/importlib_resources/issues/60 not __name__ as jnius_config.py is not a package
         resource_path = importlib.resources.files('jnius') / 'src'
         return_classpath = [ str(resource_path) ]
-        print(return_classpath)
         path = file_manager.enter_context(
             importlib.resources.as_file(resource_path))
     else:
         from pkg_resources import resource_filename
         return_classpath = [realpath(resource_filename(__name__, 'jnius/src'))]
-        print(return_classpath)
 
 
     if classpath is not None:

--- a/jnius_config.py
+++ b/jnius_config.py
@@ -83,7 +83,7 @@ def get_classpath():
         return_classpath = [ str(resource_path) ]
         print(return_classpath)
         path = file_manager.enter_context(
-            importlib.resources.as_file(return_classpath[0]))
+            importlib.resources.as_file(resource_path))
     else:
         from pkg_resources import resource_filename
         return_classpath = [realpath(resource_filename(__name__, 'jnius/src'))]

--- a/jnius_config.py
+++ b/jnius_config.py
@@ -65,7 +65,7 @@ def add_classpath(*path):
 def get_classpath():
     "Retrieves the classpath the JVM will use."
     from os import environ
-    from os.path import realpath
+    from os.path import realpath, join
     import sys
     global classpath
 
@@ -79,7 +79,7 @@ def get_classpath():
         atexit.register(file_manager.close)
         # importlib.resources.files is only available from Python 3.9
         # use https://github.com/python/importlib_resources/issues/60 not __name__ as jnius_config.py is not a package
-        return_classpath = [ importlib.resources.files(__package__) /  'jnius/src' ]
+        return_classpath = [ importlib.resources.files('jnius') / 'src' ]
         path = file_manager.enter_context(
             importlib.resources.as_file(return_classpath[0]))
     else:

--- a/jnius_config.py
+++ b/jnius_config.py
@@ -87,6 +87,7 @@ def get_classpath():
     else:
         from pkg_resources import resource_filename
         return_classpath = [realpath(resource_filename(__name__, 'jnius/src'))]
+        print(return_classpath)
 
 
     if classpath is not None:

--- a/jnius_config.py
+++ b/jnius_config.py
@@ -65,7 +65,7 @@ def add_classpath(*path):
 def get_classpath():
     "Retrieves the classpath the JVM will use."
     from os import environ
-    from os.path import realpath, join
+    from os.path import realpath
     import sys
     global classpath
 

--- a/jnius_config.py
+++ b/jnius_config.py
@@ -77,8 +77,9 @@ def get_classpath():
         # see https://importlib-resources.readthedocs.io/en/latest/migration.html#pkg-resources-resource-filename
         file_manager = ExitStack()
         atexit.register(file_manager.close)
-        #  importlib.resources.files is only availale from Python 3.9
-        return_classpath = [ importlib.resources.files(__name__) /  'jnius/src' ]
+        # importlib.resources.files is only available from Python 3.9
+        # use https://github.com/python/importlib_resources/issues/60 not __name__ as jnius_config.py is not a package
+        return_classpath = [ importlib.resources.files(__package__) /  'jnius/src' ]
         path = file_manager.enter_context(
             importlib.resources.as_file(return_classpath[0]))
     else:

--- a/jnius_config.py
+++ b/jnius_config.py
@@ -79,8 +79,8 @@ def get_classpath():
         atexit.register(file_manager.close)
         # importlib.resources.files is only available from Python 3.9
         # use https://github.com/python/importlib_resources/issues/60 not __name__ as jnius_config.py is not a package
-        resource_paths = importlib.resources.files('jnius') / 'src'
-        return_classpath = [ p.abspath() for p in resource_paths ]
+        resource_path = importlib.resources.files('jnius') / 'src'
+        return_classpath = [ str(resource_path) ]
         print(return_classpath)
         path = file_manager.enter_context(
             importlib.resources.as_file(return_classpath[0]))


### PR DESCRIPTION
As noted in #670 pkg_resources is deprecated as an API. 

For Python >=3.9, there is sufficient importlib.resources API to replace this. There is a backport (see https://importlib-resources.readthedocs.io/), but I dont think we should make a dependency on importlib_resources. 

Hence, this PR addresses the warning by using the importlib.resources when it is fully available (Python 3.9+).

Please consider this PR for 1.6.0 release cycle too. All GHAs pass.
