### PR TITLE
Ensure we test the produced wheel, and not the one from the index

### DIFF
--- a/.github/workflows/create.yml
+++ b/.github/workflows/create.yml
@@ -179,21 +179,31 @@ jobs:
 
       - name: Install pyjnius wheel + test prerequisites (Windows, macOS x64)
         if: matrix.os == 'windows-latest' || matrix.os == 'macos-latest'
-        run: python -m pip install --find-links=dist pyjnius[dev,ci]
+        # --find-links=dist --no-index is needed to avoid downloading the pyjnius wheel
+        # from the index. We need to test the wheel we just built.
+        run: |
+          python -m pip install --find-links=dist --no-index pyjnius
+          python -m pip install pyjnius[dev,ci]
 
       - name: Install pyjnius wheel + test prerequisites (Linux)
         if: matrix.os == 'ubuntu-latest' || matrix.os == 'kivy-ubuntu-arm64'
+        # --find-links=dist --no-index is needed to avoid downloading the pyjnius wheel
+        # from the index. We need to test the wheel we just built.
         run: |
           source .ci/utils.sh
           ensure_python_version ${{ matrix.python }}
-          python -m pip install --find-links=dist pyjnius[dev,ci]
+          python -m pip install --find-links=dist --no-index pyjnius
+          python -m pip install pyjnius[dev,ci]
 
       - name: Install pyjnius wheel + test prerequisites (Apple Silicon M1)
         if: matrix.os == 'apple-silicon-m1'
+        # --find-links=dist --no-index is needed to avoid downloading the pyjnius wheel
+        # from the index. We need to test the wheel we just built.
         run: |
           source .ci/osx_ci.sh
           arm64_set_path_and_python_version ${{ matrix.python }}
-          python -m pip install --find-links=dist pyjnius[dev,ci]
+          python -m pip install --find-links=dist --no-index pyjnius
+          python -m pip install pyjnius[dev,ci]
 
       - name: Test wheel (Linux, macOS Intel)
         if: (matrix.os == 'ubuntu-latest') || (matrix.os == 'kivy-ubuntu-arm64') || (matrix.os == 'macos-latest')


### PR DESCRIPTION
From [pip documentation](https://pip.pypa.io/en/stable/cli/pip_install/#finding-packages):

> pip looks for packages in a number of places: on PyPI (if not disabled via --no-index), in the local filesystem, and in any additional repositories specified via --find-links or --index-url. There is no ordering in the locations that are searched. Rather they are all checked, and the “best” match for the requirements (in terms of version number - see [PEP 440](https://peps.python.org/pep-0440/) for details) is selected.

So, unfortunately,seems that sometimes we were testing the wheel from the index, and not the produced one. 🫣
This PR ensures (by installing `pyjnius` with `--no-index`) that the proper wheel is installed.
Extras (`[dev,ci]`), can be later installed with the index enabled, as `pip` will not try to re-install `pyjnius` again.