### PR TITLE
Update cibuildwheel to perform build for Python `3.12`

### DIFF
--- a/.github/workflows/create.yml
+++ b/.github/workflows/create.yml
@@ -40,7 +40,7 @@ jobs:
         if: matrix.os == 'macos-latest' || matrix.os == 'windows-latest' || matrix.os == 'ubuntu-latest'
         uses: actions/setup-python@v4
         with:
-          python-version: '3.11'
+          python-version: '3.x'
 
       - name: Setup java
         # There's no need to setup java on ubuntu-latest, as build is done into a manylinux
@@ -57,7 +57,7 @@ jobs:
         env:
           CIBW_ARCHS: '${{ matrix.cibw_archs }}'
         run: |
-          python -m pip install cibuildwheel~=2.12.3
+          python -m pip install cibuildwheel~=2.16.2
           python -m cibuildwheel --output-dir dist
 
       - name: Install cibuildwheel & build wheels (Linux, macOS Intel)
@@ -67,7 +67,7 @@ jobs:
         run: |
           source .ci/utils.sh
           ensure_python_version 3.11
-          python -m pip install cibuildwheel~=2.12.3
+          python -m pip install cibuildwheel~=2.16.2
           python -m cibuildwheel --output-dir dist
 
       - name: upload wheels
@@ -87,7 +87,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.11'
+          python-version: '3.x'
 
       - name: Build sdist
         run: |
@@ -109,7 +109,7 @@ jobs:
     strategy:
       matrix:
         os: ['ubuntu-latest', 'macos-latest', 'windows-latest', 'kivy-ubuntu-arm64']
-        python: ['3.7', '3.8', '3.9', '3.10', '3.11', 'pypy3.7', 'pypy3.8', 'pypy3.9']
+        python: ['3.7', '3.8', '3.9', '3.10', '3.11', '3.12', 'pypy3.7', 'pypy3.8', 'pypy3.9']
         include:
           # We may would like to introduce tests also on windows-latest on x86 (win32 wheels)?
           - os: ubuntu-latest
@@ -126,6 +126,9 @@ jobs:
           - os: apple-silicon-m1
             architecture: 'aarch64'
             python: '3.11'
+          - os: apple-silicon-m1
+            architecture: 'aarch64'
+            python: '3.12'
     runs-on: ${{ matrix.os }}
     steps:
 


### PR DESCRIPTION
- Updates `cibuildwheel` to `2.16.2`, so it can perform the build for Python 3.12
- Edit the matrix to add tests for Python `3.12` on produced wheels
- Minor cleanup (We do not need to force a Python3 version) 