### PR TITLE
Add missing Python supported version label for Python 3.12

### DIFF
--- a/setup_sdist.py
+++ b/setup_sdist.py
@@ -53,6 +53,7 @@ SETUP_KWARGS = {
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
         'Topic :: Software Development :: Libraries :: Application Frameworks'
     ]
 }


### PR DESCRIPTION
- Adds a missing Python supported version label for Python 3.12