### PR TITLE
Build stdist needs Cython to perform the build [build sdist]

### DIFF
--- a/.github/workflows/create.yml
+++ b/.github/workflows/create.yml
@@ -91,7 +91,7 @@ jobs:
 
       - name: Build sdist
         run: |
-            pip install -U setuptools
+            pip install -U setuptools Cython
             python setup.py sdist
 
       - name: upload sdist


### PR DESCRIPTION
Due to https://github.com/kivy/pyjnius/pull/669 we now need `Cython` installed when performing the `sdist` build.