### PR TITLE
Skip getting version from `Cython` on Android. Instead add `ANDROID_PYJNUS_CYTHON_3` env var

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -87,8 +87,11 @@ compile_native_invocation_handler(JAVA)
 
 # generate the config.pxi
 with open(join(dirname(__file__), 'jnius', 'config.pxi'), 'w') as fd:
-    import Cython
-    cython3 = Cython.__version__.startswith('3.')
+    if PLATFORM == 'android':
+        cython3 = environ.get('ANDROID_PYJNIUS_CYTHON_3', '0') == '1'
+    else:
+        import Cython
+        cython3 = Cython.__version__.startswith('3.')
     fd.write('DEF JNIUS_PLATFORM = {0!r}\n\n'.format(PLATFORM))
     # record the Cython version, to address #669
     fd.write(f'DEF JNIUS_CYTHON_3 = {cython3}')


### PR DESCRIPTION
Similar to https://github.com/kivy/pyobjus/pull/101

And yeah, also on `python-for-android`, this will not gonna be needed it anymore when we will switch away from `setup.py build_ext`, but meanwhile this would work as a workaround.