### PR TITLE
Use the `release/v1` tag for `pypa/gh-action-pypi-publish`, as `master` is deprecated

### DIFF
--- a/.github/workflows/create.yml
+++ b/.github/workflows/create.yml
@@ -251,7 +251,7 @@ jobs:
 
     - name: Publish package
       if: startsWith(github.ref, 'refs/tags/') && endsWith(github.ref, '-test')
-      uses: pypa/gh-action-pypi-publish@master
+      uses: pypa/gh-action-pypi-publish@release/v1
       with:
         user: __token__
         password: ${{ secrets.PYPI_TOKEN_TEST }}
@@ -259,7 +259,7 @@ jobs:
 
     - name: Publish package
       if: startsWith(github.ref, 'refs/tags/') && ! endsWith(github.ref, '-test')
-      uses: pypa/gh-action-pypi-publish@master
+      uses: pypa/gh-action-pypi-publish@release/v1
       with:
         user: __token__
         password: ${{ secrets.PYPI_TOKEN }}


### PR DESCRIPTION
In this pull request, we are updating our workflow for PyPI package publishing by transitioning from the `master` branch to the `release/v1` tag in the `pypa/gh-action-pypi-publish` action, as the `master` branch is deprecated.

**Testing:**

During the upcoming release phase, comprehensive testing will be performed via PyPI's test infrastructure to ensure this change effectively works.

Fixes issue #660 