### PR TITLE
Update CHANGELOG and version for release `1.6.1`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Change Log
 
+# [1.6.1](https://github.com/kivy/pyjnius/tree/1.6.1) (2023-11-05)
+[Full Changelog](https://github.com/kivy/pyjnius/compare/1.6.0...1.6.1)
+
+**Implemented enhancements:**
+- [\#684](https://github.com/kivy/pyjnius/pull/684) Add (now mandatory) `.readthedocs.yaml` file, add docs extras and update sphinx conf
+- [\#691](https://github.com/kivy/pyjnius/pull/691) Cleanup some Java code in NativeInvocationHandler.java
+- [\#692](https://github.com/kivy/pyjnius/pull/692) Skip getting version from `Cython` on Android. Instead add `ANDROID_PYJNUS_CYTHON_3` env var
+- [\#693](https://gtihub.com/kivy/pyjnius/pull/693) Use the `release/v1` tag for `pypa/gh-action-pypi-publish`, as `master` is deprecated
+
 # [1.6.0](https://github.com/kivy/pyjnius/tree/1.6.0) (2023-10-07)
 [Full Changelog](https://github.com/kivy/pyjnius/compare/1.5.0...1.6.0)
 

--- a/jnius/__init__.py
+++ b/jnius/__init__.py
@@ -7,7 +7,7 @@ Accessing Java classes from Python.
 All the documentation is available at: http://pyjnius.readthedocs.org
 '''
 
-__version__ = '1.6.0'
+__version__ = '1.6.1'
 
 from .env import get_java_setup
 


### PR DESCRIPTION
Prepares the CHANGELOG and bumps version for new release (1.6.1)

**Key changes:**

- [\#684](https://github.com/kivy/pyjnius/pull/684) Add (now mandatory) `.readthedocs.yaml` file, add docs extras and update sphinx conf
- [\#691](https://github.com/kivy/pyjnius/pull/691) Cleanup some Java code in NativeInvocationHandler.java
- [\#692](https://github.com/kivy/pyjnius/pull/692) Skip getting version from `Cython` on Android. Instead add `ANDROID_PYJNUS_CYTHON_3` env var
- [\#693](https://gtihub.com/kivy/pyjnius/pull/693) Use the `release/v1` tag for `pypa/gh-action-pypi-publish`, as `master` is deprecated