### PR TITLE
Display Java stacktrace by default in JavaException

### DIFF
--- a/jnius/jnius_export_class.pxi
+++ b/jnius/jnius_export_class.pxi
@@ -18,7 +18,7 @@ class JavaException(Exception):
         '''
         Override __str__ so that we can see the Java stacktrace
         '''
-        rtr = super(Exception).__str__()
+        rtr = self.args[0]
         if self.stacktrace is not None:
             rtr += '\n' + '\n\t'.join(self.stacktrace)
         return rtr

--- a/jnius/jnius_export_class.pxi
+++ b/jnius/jnius_export_class.pxi
@@ -14,6 +14,12 @@ class JavaException(Exception):
         self.stacktrace = stacktrace
         Exception.__init__(self, message)
 
+    def __repr__(self):
+        '''
+        Override __repr__ so that we can see the Java stacktrace
+        '''
+        return super(Exception).__repr__() + '\n' + '\n\t'.join(self.stacktrace)
+
 
 cdef class JavaObject(object):
     '''Can contain any Java object. Used to store instance, or whatever.

--- a/jnius/jnius_export_class.pxi
+++ b/jnius/jnius_export_class.pxi
@@ -14,11 +14,14 @@ class JavaException(Exception):
         self.stacktrace = stacktrace
         Exception.__init__(self, message)
 
-    def __repr__(self):
+    def __str__(self):
         '''
-        Override __repr__ so that we can see the Java stacktrace
+        Override __str__ so that we can see the Java stacktrace
         '''
-        return super(Exception).__repr__() + '\n' + '\n\t'.join(self.stacktrace)
+        rtr = super(Exception).__str__()
+        if self.stacktrace is not None:
+            rtr += '\n' + '\n\t'.join(self.stacktrace)
+        return rtr
 
 
 cdef class JavaObject(object):

--- a/jnius/jnius_utils.pxi
+++ b/jnius/jnius_utils.pxi
@@ -76,7 +76,7 @@ cdef void check_exception(JNIEnv *j_env) except *:
             j_env[0].DeleteLocalRef(j_env, e_msg)
         j_env[0].DeleteLocalRef(j_env, exc)
 
-        raise JavaException('JVM exception occurred: %s' % (str(pyexcclass) + ":" + pymsg if pymsg is not None else pyexcclass), pyexcclass, pymsg, pystack)
+        raise JavaException('JVM exception occurred: %s' % (str(pyexcclass) + ": " + pymsg if pymsg is not None else pyexcclass), pyexcclass, pymsg, pystack)
 
 
 cdef void _append_exception_trace_messages(

--- a/jnius/jnius_utils.pxi
+++ b/jnius/jnius_utils.pxi
@@ -76,7 +76,7 @@ cdef void check_exception(JNIEnv *j_env) except *:
             j_env[0].DeleteLocalRef(j_env, e_msg)
         j_env[0].DeleteLocalRef(j_env, exc)
 
-        raise JavaException('JVM exception occurred: %s' % (pymsg + " " + str(pyexcclass) if pymsg is not None else pyexcclass), pyexcclass, pymsg, pystack)
+        raise JavaException('JVM exception occurred: %s' % (str(pyexcclass) + ":" + pymsg if pymsg is not None else pyexcclass), pyexcclass, pymsg, pystack)
 
 
 cdef void _append_exception_trace_messages(


### PR DESCRIPTION
In #203 and #623 we discussed printing the Java stacktrace by default, in order to assist developers with problems happenning within Java. This PR does this by overridding `__str__()`, without trying to mock the Python traceback (which would be more elegant, but beyond my knowhow).

Screenshot of how it looks like in Colab:
<img width="950" alt="image" src="https://github.com/kivy/pyjnius/assets/620938/6f46aa31-5e30-47b7-a0ce-321e875c6a0c">

Screenshot of how it looks like from Python cmdline:
<img width="986" alt="image" src="https://github.com/kivy/pyjnius/assets/620938/8c522ec0-36a3-4a6f-9d23-7127d7f58c4c">
