### PR TITLE
Prevent installation on apple silicon without appropriate codesigned entitlements

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -93,7 +93,10 @@ jobs:
 
     - name: (macOS) Setup test dependencies
       if: matrix.os == 'macos-latest' || matrix.os == 'apple-silicon-m1'
-      run: brew install ant
+      run: |
+        brew install ant
+        codesign -dvvvv --xml --entitlements - $(which python)
+        codesign -dvvvv --xml --entitlements - $(which java)
 
     - name: Build test classes via ant
       run: ant all

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -95,8 +95,8 @@ jobs:
       if: matrix.os == 'macos-latest' || matrix.os == 'apple-silicon-m1'
       run: |
         brew install ant
-        codesign -dvvvv --xml --entitlements - $(which python)
-        codesign -dvvvv --xml --entitlements - $(which java)
+        codesign -dvvvv --xml --entitlements - $(which python) || true
+        codesign -dvvvv --xml --entitlements - $(which java)  || true
 
     - name: Build test classes via ant
       run: ant all

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -113,7 +113,7 @@ jobs:
 
     - name: Install pyjnius with [dev, ci] extras
       run: |
-        pip install -v --timeout=120 .[dev,ci]
+        pip install --timeout=120 .[dev,ci]
   
     - name: (Windows) Test pyjnius via pytest
       if: matrix.os == 'windows-latest'

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -113,7 +113,7 @@ jobs:
 
     - name: Install pyjnius with [dev, ci] extras
       run: |
-        pip install --timeout=120 .[dev,ci]
+        pip install -v --timeout=120 .[dev,ci]
   
     - name: (Windows) Test pyjnius via pytest
       if: matrix.os == 'windows-latest'

--- a/setup.py
+++ b/setup.py
@@ -86,7 +86,6 @@ compile_native_invocation_handler(JAVA)
 
 def check_python_signing():
     import platform
-    print("****", sys.platform, platform.processor())
     # check for mac
     if sys.platform != 'darwin':
         return
@@ -98,7 +97,6 @@ def check_python_signing():
             ['/usr/bin/codesign', '--display', '--verbose=4', '--xml', '--entitlements', '-',
             sys.executable]
         ).decode("utf-8")
-        print("****", codesign)
         assert "com.apple.security.cs.disable-executable-page-protection" in codesign, (
                 ("Python (%s) was not signed with com.apple.security.cs.disable-executable-page-protection entitlement. " % sys.executable) +
                 "You should installed a version of Python that has been codesigned with this entitlement.")

--- a/setup.py
+++ b/setup.py
@@ -86,6 +86,7 @@ compile_native_invocation_handler(JAVA)
 
 def check_python_signing():
     import platform
+    print("****", sys.platform, platform.processor())
     # check for mac
     if sys.platform != 'darwin':
         return
@@ -97,6 +98,7 @@ def check_python_signing():
             ['/usr/bin/codesign', '--display', '--verbose=4', '--xml', '--entitlements', '-',
             sys.executable]
         ).decode("utf-8")
+        print("****", codesign)
         assert "com.apple.security.cs.disable-executable-page-protection" in codesign, (
                 ("Python (%s) was not signed with com.apple.security.cs.disable-executable-page-protection entitlement. " % sys.executable) +
                 "You should installed a version of Python that has been codesigned with this entitlement.")

--- a/setup.py
+++ b/setup.py
@@ -96,7 +96,7 @@ def check_python_signing():
         codesign = subprocess.check_output(
             ['/usr/bin/codesign', '--display', '--verbose=4', '--xml', '--entitlements', '-',
             sys.executable]
-        )
+        ).decode("utf-8")
         assert "com.apple.security.cs.disable-executable-page-protection" in codesign, (
                 ("Python (%s) was not signed with com.apple.security.cs.disable-executable-page-protection entitlement. " % sys.executable) +
                 "You should installed a version of Python that has been codesigned with this entitlement.")

--- a/setup.py
+++ b/setup.py
@@ -84,6 +84,27 @@ def compile_native_invocation_handler(java):
 
 compile_native_invocation_handler(JAVA)
 
+def check_python_signing():
+    import platform
+    # check for mac
+    if sys.platform != 'darwin':
+        return
+    # check for arm
+    if platform.processor() != 'arm':
+        return
+    try:
+        codesign = subprocess.check_output(
+            ['/usr/bin/codesign', '--display', '--verbose=4', '--xml', '--entitlements', '-',
+            sys.executable]
+        )
+        assert "com.apple.security.cs.disable-executable-page-protection" not in codesign, (
+                ("Python (%s) was not signed with com.apple.security.cs.disable-executable-page-protection entitlement. " % sys.executable) +
+                "You should installed a version of Python that has been codesigned with this entitlement.")
+    except:
+        assert False, (("Could not apply codesign to %s. Codesign is required for Apple Silicon. You should installed a version of " +
+            "Python installed that has been codesigned") % sys.executable)
+
+check_python_signing()
 
 # generate the config.pxi
 with open(join(dirname(__file__), 'jnius', 'config.pxi'), 'w') as fd:

--- a/setup.py
+++ b/setup.py
@@ -97,7 +97,7 @@ def check_python_signing():
             ['/usr/bin/codesign', '--display', '--verbose=4', '--xml', '--entitlements', '-',
             sys.executable]
         )
-        assert "com.apple.security.cs.disable-executable-page-protection" not in codesign, (
+        assert "com.apple.security.cs.disable-executable-page-protection" in codesign, (
                 ("Python (%s) was not signed with com.apple.security.cs.disable-executable-page-protection entitlement. " % sys.executable) +
                 "You should installed a version of Python that has been codesigned with this entitlement.")
     except:


### PR DESCRIPTION
At this stage, I just want to see the signing and entitlement status of java and python executables on apple-silicon