### PR TITLE
Support installing and testing using only a JRE 

### DIFF
--- a/.github/workflows/create.yml
+++ b/.github/workflows/create.yml
@@ -152,6 +152,7 @@ jobs:
         with:
           java-version: '17'
           distribution: 'temurin'
+          java-package: 'jre'
           architecture: ${{ matrix.architecture }}
 
       - name: Setup ant on macOS

--- a/.github/workflows/test-wheels.yml
+++ b/.github/workflows/test-wheels.yml
@@ -1,0 +1,210 @@
+on:
+    push:
+    pull_request:
+    create:
+  
+  name: Continuous Integration - Testing Wheels on JREs
+  jobs:
+    build_wheels:
+      name: cibuildwheel on ${{ matrix.os }} ${{ matrix.architecture }}
+      env:
+        CIBW_BEFORE_ALL_LINUX: 'yum install -y java-11-openjdk-devel'
+        CIBW_REPAIR_WHEEL_COMMAND_MACOS: ''
+        CIBW_SKIP: 'cp36-* *musllinux*'
+      strategy:
+        matrix:
+          include:
+            - os: windows-latest
+              architecture: 'x86'
+              cibw_archs: 'x86'
+            - os: windows-latest
+              architecture: 'x64'
+              cibw_archs: 'AMD64'
+            - os: ubuntu-latest
+              architecture: 'x64'
+              cibw_archs: 'x86_64'
+            - os: kivy-ubuntu-arm64
+              architecture: 'aarch64'
+              cibw_archs: aarch64
+            - os: macos-latest
+              architecture: 'x64'
+              cibw_archs: 'x86_64 universal2'
+      runs-on: ${{ matrix.os }}
+      steps:
+  
+        - name: Checkout pyjnius
+          uses: actions/checkout@v3
+  
+        - name: Setup Python (Ubuntu x86_64, macOS Intel, Windows x86_64)
+          if: matrix.os == 'macos-latest' || matrix.os == 'windows-latest' || matrix.os == 'ubuntu-latest'
+          uses: actions/setup-python@v4
+          with:
+            python-version: '3.x'
+  
+        - name: Setup java
+          # There's no need to setup java on ubuntu-latest, as build is done into a manylinux
+          # containerized environment. (CIBW_BEFORE_ALL_LINUX) takes care of it.
+          if: ${{ matrix.os  != 'ubuntu-latest' }}
+          uses: actions/setup-java@v3
+          with:
+            java-version: '17'
+            distribution: 'temurin'
+            architecture: ${{ matrix.architecture }}
+  
+        - name: Install cibuildwheel & build wheels (Windows)
+          if: matrix.os == 'windows-latest'
+          env:
+            CIBW_ARCHS: '${{ matrix.cibw_archs }}'
+          run: |
+            python -m pip install cibuildwheel~=2.16.2
+            python -m cibuildwheel --output-dir dist
+  
+        - name: Install cibuildwheel & build wheels (Linux, macOS Intel)
+          if: (matrix.os == 'ubuntu-latest') || (matrix.os == 'kivy-ubuntu-arm64') ||  (matrix.os == 'macos-latest')
+          env:
+            CIBW_ARCHS: '${{ matrix.cibw_archs }}'
+          run: |
+            source .ci/utils.sh
+            ensure_python_version 3.11
+            python -m pip install cibuildwheel~=2.16.2
+            python -m cibuildwheel --output-dir dist
+  
+        - name: upload wheels
+          uses: actions/upload-artifact@v2
+          with:
+            name: dist
+            path: dist
+  
+    build_sdist:
+      name: Build sdist
+      if: (github.event_name == 'create' && github.event.ref_type == 'tag') || contains(github.event.head_commit.message, '[build sdist]') || contains(github.event.pull_request.title, '[build sdist]')
+      runs-on: 'ubuntu-latest'
+      steps:
+        - name: Checkout pyjnius
+          uses: actions/checkout@v3
+  
+        - name: Setup Python
+          uses: actions/setup-python@v4
+          with:
+            python-version: '3.x'
+  
+        - name: Build sdist
+          run: |
+              pip install -U setuptools Cython
+              python setup.py sdist
+  
+        - name: upload sdist
+          uses: actions/upload-artifact@v2
+          with:
+            name: dist
+            path: dist
+  
+    test_wheels:
+      name: Test wheel on ${{ matrix.os }} (${{ matrix.architecture }}) Python ${{ matrix.python }}
+      if: (github.event_name == 'create' && github.event.ref_type == 'tag') || contains(github.event.head_commit.message, '[build wheel]') || contains(github.event.pull_request.title, '[build wheel]')
+      needs:
+        - build_wheels
+      continue-on-error: true
+      strategy:
+        matrix:
+          os: ['ubuntu-latest', 'macos-latest', 'windows-latest', 'kivy-ubuntu-arm64']
+          python: ['3.7', '3.8', '3.9', '3.10', '3.11', '3.12', 'pypy3.7', 'pypy3.8', 'pypy3.9']
+          include:
+            # We may would like to introduce tests also on windows-latest on x86 (win32 wheels)?
+            - os: ubuntu-latest
+              architecture: 'x64'
+            - os: kivy-ubuntu-arm64
+              architecture: 'aarch64'
+            - os: windows-latest
+              architecture: 'x64'
+            - os: macos-latest
+              architecture: 'x64'
+            - os: apple-silicon-m1
+              architecture: 'aarch64'
+              python: '3.10'
+            - os: apple-silicon-m1
+              architecture: 'aarch64'
+              python: '3.11'
+            - os: apple-silicon-m1
+              architecture: 'aarch64'
+              python: '3.12'
+      runs-on: ${{ matrix.os }}
+      steps:
+  
+        - name: Checkout pyjnius
+          uses: actions/checkout@v3
+  
+        - uses: actions/download-artifact@v2
+          with:
+            name: dist
+            path: dist
+  
+        - name: Setup Python (Ubuntu x86_64, macOS Intel, Windows x86_64)
+          # Needs to be skipped on our self-hosted runners tagged as 'apple-silicon-m1'
+          if: matrix.os == 'macos-latest' || matrix.os == 'windows-latest' || matrix.os == 'ubuntu-latest' || matrix.os == 'apple-silicon-m1'
+          uses: actions/setup-python@v4
+          with:
+            python-version: ${{ matrix.python }}
+  
+        - name: Setup java
+          uses: actions/setup-java@v3
+          with:
+            java-version: '17'
+            distribution: 'temurin'
+            java-package: 'jre'
+            architecture: ${{ matrix.architecture }}
+  
+        - name: Setup ant on macOS
+          if: (matrix.os == 'macos-latest') || (matrix.os == 'apple-silicon-m1')
+          run: |
+            brew install ant
+  
+        - name: Setup ant on Linux
+          if: (matrix.os == 'ubuntu-latest') || (matrix.os == 'kivy-ubuntu-arm64')
+          run: |
+            sudo apt-get update && sudo apt-get install -y ant
+  
+        - name: Build test-classes via ant
+          run: ant all
+  
+        - name: Install pyjnius wheel + test prerequisites (Windows, macOS)
+          if: matrix.os == 'windows-latest' || matrix.os == 'macos-latest' || matrix.os == 'apple-silicon-m1'
+          # --find-links=dist --no-index is needed to avoid downloading the pyjnius wheel
+          # from the index. We need to test the wheel we just built.
+          run: |
+            python -m pip install --find-links=dist --no-index pyjnius
+            python -m pip install pyjnius[dev,ci]
+  
+        - name: Install pyjnius wheel + test prerequisites (Linux)
+          if: matrix.os == 'ubuntu-latest' || matrix.os == 'kivy-ubuntu-arm64'
+          # --find-links=dist --no-index is needed to avoid downloading the pyjnius wheel
+          # from the index. We need to test the wheel we just built.
+          run: |
+            source .ci/utils.sh
+            ensure_python_version ${{ matrix.python }}
+            python -m pip install --find-links=dist --no-index pyjnius
+            python -m pip install pyjnius[dev,ci]
+  
+        - name: Test wheel (Linux, macOS)
+          if: (matrix.os == 'ubuntu-latest') || (matrix.os == 'kivy-ubuntu-arm64') || (matrix.os == 'macos-latest') || (matrix.os == 'apple-silicon-m1')
+          run: |
+            source .ci/utils.sh
+            ensure_python_version ${{ matrix.python }}
+            cd tests
+            CLASSPATH=../build/test-classes:../build/classes python -m pytest -v
+  
+        - name: Test wheel ( Windows + Python == 3.7.x )
+          # On Python < 3.8.x, we can't use `os.add_dll_directory`, so the jre should be in PATH.
+          if: (matrix.os == 'windows-latest') && contains(matrix.python, '3.7')
+          run: |
+            cd tests
+            $env:PATH +=";$env:JAVA_HOME\jre\bin\server\;$env:JAVA_HOME\jre\bin\client\;$env:JAVA_HOME\bin\server\"
+            $env:CLASSPATH ="../build/test-classes;../build/classes"
+            python -m pytest -v
+  
+        - name: Test wheel (Windows + Python != 3.7.x )
+          if: (matrix.os == 'windows-latest') && !contains(matrix.python, '3.7')
+          run: |
+            cd tests
+            $env:CLASSPATH ="../build/test-classes;../build/classes"
+            python -m pytest -v

--- a/.github/workflows/test-wheels.yml
+++ b/.github/workflows/test-wheels.yml
@@ -23,9 +23,6 @@ jobs:
           - os: ubuntu-latest
             architecture: 'x64'
             cibw_archs: 'x86_64'
-          - os: kivy-ubuntu-arm64
-            architecture: 'aarch64'
-            cibw_archs: aarch64
           - os: macos-latest
             architecture: 'x64'
             cibw_archs: 'x86_64 universal2'
@@ -113,8 +110,6 @@ jobs:
           # We may would like to introduce tests also on windows-latest on x86 (win32 wheels)?
           - os: ubuntu-latest
             architecture: 'x64'
-          - os: kivy-ubuntu-arm64
-            architecture: 'aarch64'
           - os: windows-latest
             architecture: 'x64'
           - os: macos-latest

--- a/.github/workflows/test-wheels.yml
+++ b/.github/workflows/test-wheels.yml
@@ -3,208 +3,208 @@ on:
     pull_request:
     create:
   
-  name: Continuous Integration - Testing Wheels on JREs
-  jobs:
-    build_wheels:
-      name: cibuildwheel on ${{ matrix.os }} ${{ matrix.architecture }}
-      env:
-        CIBW_BEFORE_ALL_LINUX: 'yum install -y java-11-openjdk-devel'
-        CIBW_REPAIR_WHEEL_COMMAND_MACOS: ''
-        CIBW_SKIP: 'cp36-* *musllinux*'
-      strategy:
-        matrix:
-          include:
-            - os: windows-latest
-              architecture: 'x86'
-              cibw_archs: 'x86'
-            - os: windows-latest
-              architecture: 'x64'
-              cibw_archs: 'AMD64'
-            - os: ubuntu-latest
-              architecture: 'x64'
-              cibw_archs: 'x86_64'
-            - os: kivy-ubuntu-arm64
-              architecture: 'aarch64'
-              cibw_archs: aarch64
-            - os: macos-latest
-              architecture: 'x64'
-              cibw_archs: 'x86_64 universal2'
-      runs-on: ${{ matrix.os }}
-      steps:
-  
-        - name: Checkout pyjnius
-          uses: actions/checkout@v3
-  
-        - name: Setup Python (Ubuntu x86_64, macOS Intel, Windows x86_64)
-          if: matrix.os == 'macos-latest' || matrix.os == 'windows-latest' || matrix.os == 'ubuntu-latest'
-          uses: actions/setup-python@v4
-          with:
-            python-version: '3.x'
-  
-        - name: Setup java
-          # There's no need to setup java on ubuntu-latest, as build is done into a manylinux
-          # containerized environment. (CIBW_BEFORE_ALL_LINUX) takes care of it.
-          if: ${{ matrix.os  != 'ubuntu-latest' }}
-          uses: actions/setup-java@v3
-          with:
-            java-version: '17'
-            distribution: 'temurin'
-            architecture: ${{ matrix.architecture }}
-  
-        - name: Install cibuildwheel & build wheels (Windows)
-          if: matrix.os == 'windows-latest'
-          env:
-            CIBW_ARCHS: '${{ matrix.cibw_archs }}'
-          run: |
-            python -m pip install cibuildwheel~=2.16.2
-            python -m cibuildwheel --output-dir dist
-  
-        - name: Install cibuildwheel & build wheels (Linux, macOS Intel)
-          if: (matrix.os == 'ubuntu-latest') || (matrix.os == 'kivy-ubuntu-arm64') ||  (matrix.os == 'macos-latest')
-          env:
-            CIBW_ARCHS: '${{ matrix.cibw_archs }}'
-          run: |
-            source .ci/utils.sh
-            ensure_python_version 3.11
-            python -m pip install cibuildwheel~=2.16.2
-            python -m cibuildwheel --output-dir dist
-  
-        - name: upload wheels
-          uses: actions/upload-artifact@v2
-          with:
-            name: dist
-            path: dist
-  
-    build_sdist:
-      name: Build sdist
-      if: (github.event_name == 'create' && github.event.ref_type == 'tag') || contains(github.event.head_commit.message, '[build sdist]') || contains(github.event.pull_request.title, '[build sdist]')
-      runs-on: 'ubuntu-latest'
-      steps:
-        - name: Checkout pyjnius
-          uses: actions/checkout@v3
-  
-        - name: Setup Python
-          uses: actions/setup-python@v4
-          with:
-            python-version: '3.x'
-  
-        - name: Build sdist
-          run: |
-              pip install -U setuptools Cython
-              python setup.py sdist
-  
-        - name: upload sdist
-          uses: actions/upload-artifact@v2
-          with:
-            name: dist
-            path: dist
-  
-    test_wheels:
-      name: Test wheel on ${{ matrix.os }} (${{ matrix.architecture }}) Python ${{ matrix.python }}
-      if: (github.event_name == 'create' && github.event.ref_type == 'tag') || contains(github.event.head_commit.message, '[build wheel]') || contains(github.event.pull_request.title, '[build wheel]')
-      needs:
-        - build_wheels
-      continue-on-error: true
-      strategy:
-        matrix:
-          os: ['ubuntu-latest', 'macos-latest', 'windows-latest', 'kivy-ubuntu-arm64']
-          python: ['3.7', '3.8', '3.9', '3.10', '3.11', '3.12', 'pypy3.7', 'pypy3.8', 'pypy3.9']
-          include:
-            # We may would like to introduce tests also on windows-latest on x86 (win32 wheels)?
-            - os: ubuntu-latest
-              architecture: 'x64'
-            - os: kivy-ubuntu-arm64
-              architecture: 'aarch64'
-            - os: windows-latest
-              architecture: 'x64'
-            - os: macos-latest
-              architecture: 'x64'
-            - os: apple-silicon-m1
-              architecture: 'aarch64'
-              python: '3.10'
-            - os: apple-silicon-m1
-              architecture: 'aarch64'
-              python: '3.11'
-            - os: apple-silicon-m1
-              architecture: 'aarch64'
-              python: '3.12'
-      runs-on: ${{ matrix.os }}
-      steps:
-  
-        - name: Checkout pyjnius
-          uses: actions/checkout@v3
-  
-        - uses: actions/download-artifact@v2
-          with:
-            name: dist
-            path: dist
-  
-        - name: Setup Python (Ubuntu x86_64, macOS Intel, Windows x86_64)
-          # Needs to be skipped on our self-hosted runners tagged as 'apple-silicon-m1'
-          if: matrix.os == 'macos-latest' || matrix.os == 'windows-latest' || matrix.os == 'ubuntu-latest' || matrix.os == 'apple-silicon-m1'
-          uses: actions/setup-python@v4
-          with:
-            python-version: ${{ matrix.python }}
-  
-        - name: Setup java
-          uses: actions/setup-java@v3
-          with:
-            java-version: '17'
-            distribution: 'temurin'
-            java-package: 'jre'
-            architecture: ${{ matrix.architecture }}
-  
-        - name: Setup ant on macOS
-          if: (matrix.os == 'macos-latest') || (matrix.os == 'apple-silicon-m1')
-          run: |
-            brew install ant
-  
-        - name: Setup ant on Linux
-          if: (matrix.os == 'ubuntu-latest') || (matrix.os == 'kivy-ubuntu-arm64')
-          run: |
-            sudo apt-get update && sudo apt-get install -y ant
-  
-        - name: Build test-classes via ant
-          run: ant all
-  
-        - name: Install pyjnius wheel + test prerequisites (Windows, macOS)
-          if: matrix.os == 'windows-latest' || matrix.os == 'macos-latest' || matrix.os == 'apple-silicon-m1'
-          # --find-links=dist --no-index is needed to avoid downloading the pyjnius wheel
-          # from the index. We need to test the wheel we just built.
-          run: |
-            python -m pip install --find-links=dist --no-index pyjnius
-            python -m pip install pyjnius[dev,ci]
-  
-        - name: Install pyjnius wheel + test prerequisites (Linux)
-          if: matrix.os == 'ubuntu-latest' || matrix.os == 'kivy-ubuntu-arm64'
-          # --find-links=dist --no-index is needed to avoid downloading the pyjnius wheel
-          # from the index. We need to test the wheel we just built.
-          run: |
-            source .ci/utils.sh
-            ensure_python_version ${{ matrix.python }}
-            python -m pip install --find-links=dist --no-index pyjnius
-            python -m pip install pyjnius[dev,ci]
-  
-        - name: Test wheel (Linux, macOS)
-          if: (matrix.os == 'ubuntu-latest') || (matrix.os == 'kivy-ubuntu-arm64') || (matrix.os == 'macos-latest') || (matrix.os == 'apple-silicon-m1')
-          run: |
-            source .ci/utils.sh
-            ensure_python_version ${{ matrix.python }}
-            cd tests
-            CLASSPATH=../build/test-classes:../build/classes python -m pytest -v
-  
-        - name: Test wheel ( Windows + Python == 3.7.x )
-          # On Python < 3.8.x, we can't use `os.add_dll_directory`, so the jre should be in PATH.
-          if: (matrix.os == 'windows-latest') && contains(matrix.python, '3.7')
-          run: |
-            cd tests
-            $env:PATH +=";$env:JAVA_HOME\jre\bin\server\;$env:JAVA_HOME\jre\bin\client\;$env:JAVA_HOME\bin\server\"
-            $env:CLASSPATH ="../build/test-classes;../build/classes"
-            python -m pytest -v
-  
-        - name: Test wheel (Windows + Python != 3.7.x )
-          if: (matrix.os == 'windows-latest') && !contains(matrix.python, '3.7')
-          run: |
-            cd tests
-            $env:CLASSPATH ="../build/test-classes;../build/classes"
-            python -m pytest -v
+name: Continuous Integration - Testing Wheels on JREs
+jobs:
+  build_wheels:
+    name: cibuildwheel on ${{ matrix.os }} ${{ matrix.architecture }}
+    env:
+      CIBW_BEFORE_ALL_LINUX: 'yum install -y java-11-openjdk-devel'
+      CIBW_REPAIR_WHEEL_COMMAND_MACOS: ''
+      CIBW_SKIP: 'cp36-* *musllinux*'
+    strategy:
+      matrix:
+        include:
+          - os: windows-latest
+            architecture: 'x86'
+            cibw_archs: 'x86'
+          - os: windows-latest
+            architecture: 'x64'
+            cibw_archs: 'AMD64'
+          - os: ubuntu-latest
+            architecture: 'x64'
+            cibw_archs: 'x86_64'
+          - os: kivy-ubuntu-arm64
+            architecture: 'aarch64'
+            cibw_archs: aarch64
+          - os: macos-latest
+            architecture: 'x64'
+            cibw_archs: 'x86_64 universal2'
+    runs-on: ${{ matrix.os }}
+    steps:
+
+      - name: Checkout pyjnius
+        uses: actions/checkout@v3
+
+      - name: Setup Python (Ubuntu x86_64, macOS Intel, Windows x86_64)
+        if: matrix.os == 'macos-latest' || matrix.os == 'windows-latest' || matrix.os == 'ubuntu-latest'
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+
+      - name: Setup java
+        # There's no need to setup java on ubuntu-latest, as build is done into a manylinux
+        # containerized environment. (CIBW_BEFORE_ALL_LINUX) takes care of it.
+        if: ${{ matrix.os  != 'ubuntu-latest' }}
+        uses: actions/setup-java@v3
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+          architecture: ${{ matrix.architecture }}
+
+      - name: Install cibuildwheel & build wheels (Windows)
+        if: matrix.os == 'windows-latest'
+        env:
+          CIBW_ARCHS: '${{ matrix.cibw_archs }}'
+        run: |
+          python -m pip install cibuildwheel~=2.16.2
+          python -m cibuildwheel --output-dir dist
+
+      - name: Install cibuildwheel & build wheels (Linux, macOS Intel)
+        if: (matrix.os == 'ubuntu-latest') || (matrix.os == 'kivy-ubuntu-arm64') ||  (matrix.os == 'macos-latest')
+        env:
+          CIBW_ARCHS: '${{ matrix.cibw_archs }}'
+        run: |
+          source .ci/utils.sh
+          ensure_python_version 3.11
+          python -m pip install cibuildwheel~=2.16.2
+          python -m cibuildwheel --output-dir dist
+
+      - name: upload wheels
+        uses: actions/upload-artifact@v2
+        with:
+          name: dist
+          path: dist
+
+  build_sdist:
+    name: Build sdist
+    if: (github.event_name == 'create' && github.event.ref_type == 'tag') || contains(github.event.head_commit.message, '[build sdist]') || contains(github.event.pull_request.title, '[build sdist]')
+    runs-on: 'ubuntu-latest'
+    steps:
+      - name: Checkout pyjnius
+        uses: actions/checkout@v3
+
+      - name: Setup Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+
+      - name: Build sdist
+        run: |
+            pip install -U setuptools Cython
+            python setup.py sdist
+
+      - name: upload sdist
+        uses: actions/upload-artifact@v2
+        with:
+          name: dist
+          path: dist
+
+  test_wheels:
+    name: Test wheel on ${{ matrix.os }} (${{ matrix.architecture }}) Python ${{ matrix.python }}
+    if: (github.event_name == 'create' && github.event.ref_type == 'tag') || contains(github.event.head_commit.message, '[build wheel]') || contains(github.event.pull_request.title, '[build wheel]')
+    needs:
+      - build_wheels
+    continue-on-error: true
+    strategy:
+      matrix:
+        os: ['ubuntu-latest', 'macos-latest', 'windows-latest', 'kivy-ubuntu-arm64']
+        python: ['3.7', '3.8', '3.9', '3.10', '3.11', '3.12', 'pypy3.7', 'pypy3.8', 'pypy3.9']
+        include:
+          # We may would like to introduce tests also on windows-latest on x86 (win32 wheels)?
+          - os: ubuntu-latest
+            architecture: 'x64'
+          - os: kivy-ubuntu-arm64
+            architecture: 'aarch64'
+          - os: windows-latest
+            architecture: 'x64'
+          - os: macos-latest
+            architecture: 'x64'
+          - os: apple-silicon-m1
+            architecture: 'aarch64'
+            python: '3.10'
+          - os: apple-silicon-m1
+            architecture: 'aarch64'
+            python: '3.11'
+          - os: apple-silicon-m1
+            architecture: 'aarch64'
+            python: '3.12'
+    runs-on: ${{ matrix.os }}
+    steps:
+
+      - name: Checkout pyjnius
+        uses: actions/checkout@v3
+
+      - uses: actions/download-artifact@v2
+        with:
+          name: dist
+          path: dist
+
+      - name: Setup Python (Ubuntu x86_64, macOS Intel, Windows x86_64)
+        # Needs to be skipped on our self-hosted runners tagged as 'apple-silicon-m1'
+        if: matrix.os == 'macos-latest' || matrix.os == 'windows-latest' || matrix.os == 'ubuntu-latest' || matrix.os == 'apple-silicon-m1'
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python }}
+
+      - name: Setup java
+        uses: actions/setup-java@v3
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+          java-package: 'jre'
+          architecture: ${{ matrix.architecture }}
+
+      - name: Setup ant on macOS
+        if: (matrix.os == 'macos-latest') || (matrix.os == 'apple-silicon-m1')
+        run: |
+          brew install ant
+
+      - name: Setup ant on Linux
+        if: (matrix.os == 'ubuntu-latest') || (matrix.os == 'kivy-ubuntu-arm64')
+        run: |
+          sudo apt-get update && sudo apt-get install -y ant
+
+      - name: Build test-classes via ant
+        run: ant all
+
+      - name: Install pyjnius wheel + test prerequisites (Windows, macOS)
+        if: matrix.os == 'windows-latest' || matrix.os == 'macos-latest' || matrix.os == 'apple-silicon-m1'
+        # --find-links=dist --no-index is needed to avoid downloading the pyjnius wheel
+        # from the index. We need to test the wheel we just built.
+        run: |
+          python -m pip install --find-links=dist --no-index pyjnius
+          python -m pip install pyjnius[dev,ci]
+
+      - name: Install pyjnius wheel + test prerequisites (Linux)
+        if: matrix.os == 'ubuntu-latest' || matrix.os == 'kivy-ubuntu-arm64'
+        # --find-links=dist --no-index is needed to avoid downloading the pyjnius wheel
+        # from the index. We need to test the wheel we just built.
+        run: |
+          source .ci/utils.sh
+          ensure_python_version ${{ matrix.python }}
+          python -m pip install --find-links=dist --no-index pyjnius
+          python -m pip install pyjnius[dev,ci]
+
+      - name: Test wheel (Linux, macOS)
+        if: (matrix.os == 'ubuntu-latest') || (matrix.os == 'kivy-ubuntu-arm64') || (matrix.os == 'macos-latest') || (matrix.os == 'apple-silicon-m1')
+        run: |
+          source .ci/utils.sh
+          ensure_python_version ${{ matrix.python }}
+          cd tests
+          CLASSPATH=../build/test-classes:../build/classes python -m pytest -v
+
+      - name: Test wheel ( Windows + Python == 3.7.x )
+        # On Python < 3.8.x, we can't use `os.add_dll_directory`, so the jre should be in PATH.
+        if: (matrix.os == 'windows-latest') && contains(matrix.python, '3.7')
+        run: |
+          cd tests
+          $env:PATH +=";$env:JAVA_HOME\jre\bin\server\;$env:JAVA_HOME\jre\bin\client\;$env:JAVA_HOME\bin\server\"
+          $env:CLASSPATH ="../build/test-classes;../build/classes"
+          python -m pytest -v
+
+      - name: Test wheel (Windows + Python != 3.7.x )
+        if: (matrix.os == 'windows-latest') && !contains(matrix.python, '3.7')
+        run: |
+          cd tests
+          $env:CLASSPATH ="../build/test-classes;../build/classes"
+          python -m pytest -v

--- a/.github/workflows/test-wheels.yml
+++ b/.github/workflows/test-wheels.yml
@@ -118,15 +118,15 @@ jobs:
             architecture: 'x64'
           - os: macos-latest
             architecture: 'x64'
-          #- os: apple-silicon-m1
-          #  architecture: 'aarch64'
-          #  python: '3.10'
-          #- os: apple-silicon-m1
-          #  architecture: 'aarch64'
-          #  python: '3.11'
-          #- os: apple-silicon-m1
-          #  architecture: 'aarch64'
-          #  python: '3.12'
+          - os: apple-silicon-m1
+            architecture: 'aarch64'
+            python: '3.10'
+          - os: apple-silicon-m1
+            architecture: 'aarch64'
+            python: '3.11'
+          - os: apple-silicon-m1
+            architecture: 'aarch64'
+            python: '3.12'
     runs-on: ${{ matrix.os }}
     steps:
 

--- a/.github/workflows/test-wheels.yml
+++ b/.github/workflows/test-wheels.yml
@@ -5,6 +5,35 @@ on:
   
 name: Continuous Integration - Testing Wheels on JREs
 jobs:
+  build_test_jar:
+    runs-on: 'ubuntu-latest'
+    steps:
+
+      - name: Checkout pyjnius
+        uses: actions/checkout@v3
+
+      - name: Setup java
+        # There's no need to setup java on ubuntu-latest, as build is done into a manylinux
+        # containerized environment. (CIBW_BEFORE_ALL_LINUX) takes care of it.
+        uses: actions/setup-java@v3
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+          architecture: 'x64'
+
+      - name: Setup ant on Linux
+        run: |
+          sudo apt-get update && sudo apt-get install -y ant
+
+      - name: Build test-classes via ant
+        run: ant all
+
+      - name: Upload test-classes
+        uses: actions/upload-artifact@v3
+        with:
+          name: test-classes
+          path: build/test-classes
+          
   build_wheels:
     name: cibuildwheel on ${{ matrix.os }} ${{ matrix.architecture }}
     env:
@@ -67,7 +96,7 @@ jobs:
           python -m cibuildwheel --output-dir dist
 
       - name: upload wheels
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: dist
           path: dist
@@ -89,25 +118,30 @@ jobs:
             architecture: 'x64'
           - os: macos-latest
             architecture: 'x64'
-          - os: apple-silicon-m1
-            architecture: 'aarch64'
-            python: '3.10'
-          - os: apple-silicon-m1
-            architecture: 'aarch64'
-            python: '3.11'
-          - os: apple-silicon-m1
-            architecture: 'aarch64'
-            python: '3.12'
+          #- os: apple-silicon-m1
+          #  architecture: 'aarch64'
+          #  python: '3.10'
+          #- os: apple-silicon-m1
+          #  architecture: 'aarch64'
+          #  python: '3.11'
+          #- os: apple-silicon-m1
+          #  architecture: 'aarch64'
+          #  python: '3.12'
     runs-on: ${{ matrix.os }}
     steps:
 
       - name: Checkout pyjnius
         uses: actions/checkout@v3
 
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: dist
           path: dist
+
+      - uses: actions/download-artifact@v3
+        with:
+          name: test-classes
+          path: build/test-classes
 
       - name: Setup Python (Ubuntu x86_64, macOS Intel, Windows x86_64)
         # Needs to be skipped on our self-hosted runners tagged as 'apple-silicon-m1'
@@ -123,19 +157,6 @@ jobs:
           distribution: 'temurin'
           java-package: 'jre'
           architecture: ${{ matrix.architecture }}
-
-      - name: Setup ant on macOS
-        if: (matrix.os == 'macos-latest') || (matrix.os == 'apple-silicon-m1')
-        run: |
-          brew install ant
-
-      - name: Setup ant on Linux
-        if: (matrix.os == 'ubuntu-latest') || (matrix.os == 'kivy-ubuntu-arm64')
-        run: |
-          sudo apt-get update && sudo apt-get install -y ant
-
-      - name: Build test-classes via ant
-        run: ant all
 
       - name: Install pyjnius wheel + test prerequisites (Windows, macOS)
         if: matrix.os == 'windows-latest' || matrix.os == 'macos-latest' || matrix.os == 'apple-silicon-m1'

--- a/.github/workflows/test-wheels.yml
+++ b/.github/workflows/test-wheels.yml
@@ -72,33 +72,8 @@ jobs:
           name: dist
           path: dist
 
-  build_sdist:
-    name: Build sdist
-    if: (github.event_name == 'create' && github.event.ref_type == 'tag') || contains(github.event.head_commit.message, '[build sdist]') || contains(github.event.pull_request.title, '[build sdist]')
-    runs-on: 'ubuntu-latest'
-    steps:
-      - name: Checkout pyjnius
-        uses: actions/checkout@v3
-
-      - name: Setup Python
-        uses: actions/setup-python@v4
-        with:
-          python-version: '3.x'
-
-      - name: Build sdist
-        run: |
-            pip install -U setuptools Cython
-            python setup.py sdist
-
-      - name: upload sdist
-        uses: actions/upload-artifact@v2
-        with:
-          name: dist
-          path: dist
-
   test_wheels:
     name: Test wheel on ${{ matrix.os }} (${{ matrix.architecture }}) Python ${{ matrix.python }}
-    if: (github.event_name == 'create' && github.event.ref_type == 'tag') || contains(github.event.head_commit.message, '[build wheel]') || contains(github.event.pull_request.title, '[build wheel]')
     needs:
       - build_wheels
     continue-on-error: true

--- a/docs/source/building.rst
+++ b/docs/source/building.rst
@@ -6,9 +6,9 @@ Building PyJNIus
 Building PyJNIus is necessary for development purposes, or if there is no 
 pre-built binary for your particular platform. 
 
-Like installation of PyJNIus, building PyJNIus requires a  `Java Development Kit
+Building PyJNIus requires a  `Java Development Kit
 <https://www.oracle.com/java/technologies/downloads/>`_  (JDK)
-to be installed.
+to be installed (NB: installing pre-built wheels required only a JRE).
 
 Apart from the JDK, the build requirements for each platform are as follows:
 

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -16,10 +16,11 @@ If there is no pre-compiled binary available, pip install will aim to compile
 a binary on your operating system. For more information see the :ref:`building` 
 documentation.
 
-You will need the Java JDK installed (`OpenJDK <https://openjdk.org/>`_ is fine).
+You will need the Java JRE installed (`OpenJDK <https://openjdk.org/>`_ is fine).
 PyJNIus searches for Java in the usual places on each operating system. If PyJNIus 
 cannot find Java, set the `JAVA_HOME` environment variable (this is often needed 
 `on Windows <https://www.baeldung.com/java-home-on-windows-7-8-10-mac-os-x-linux#windows>`_).
+NB: Building pyjnius requires a Java JDK rather than a JRE.
 
 Installation for Android
 ------------------------


### PR DESCRIPTION
#699 asked if a JDK was really required, or if a JRE is sufficient.

This creates a new Github Action that tests if the JREs (rather than JDKs) are sufficient to run and test pyjnius. I started from create.yml, but had to add a new stage that uses ant to obtain the `build/test-classes` folder.

The answer appears to be positive.

Note that building jnius still requires a JDK. I've updated the documentation.