### PR TITLE
require minimum python version in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,6 @@
+[project]
+requires-python = ">= 3.7"
+
 [build-system]
 requires = [
     "setuptools>=58.0.0",


### PR DESCRIPTION
noted in #618
i chose to change pyproject.toml - is this better than changing setup.py?

(actually SETUP_KWARGS in https://github.com/kivy/pyjnius/blob/master/setup_sdist.py#L26)