### PR TITLE
[build wheel] Use the new Ubuntu ARM64 runner

### DIFF
--- a/.github/workflows/create.yml
+++ b/.github/workflows/create.yml
@@ -24,7 +24,7 @@ jobs:
           - os: ubuntu-latest
             architecture: 'x64'
             cibw_archs: 'x86_64'
-          - os: kivy-ubuntu-arm64
+          - os: kivy-ubuntu-22.04-arm64
             architecture: 'aarch64'
             cibw_archs: aarch64
           - os: macos-latest
@@ -61,7 +61,7 @@ jobs:
           python -m cibuildwheel --output-dir dist
 
       - name: Install cibuildwheel & build wheels (Linux, macOS Intel)
-        if: (matrix.os == 'ubuntu-latest') || (matrix.os == 'kivy-ubuntu-arm64') ||  (matrix.os == 'macos-latest')
+        if: (matrix.os == 'ubuntu-latest') || (matrix.os == 'kivy-ubuntu-22.04-arm64') ||  (matrix.os == 'macos-latest')
         env:
           CIBW_ARCHS: '${{ matrix.cibw_archs }}'
         run: |
@@ -108,13 +108,13 @@ jobs:
     continue-on-error: true
     strategy:
       matrix:
-        os: ['ubuntu-latest', 'macos-latest', 'windows-latest', 'kivy-ubuntu-arm64']
+        os: ['ubuntu-latest', 'macos-latest', 'windows-latest', 'kivy-ubuntu-22.04-arm64']
         python: ['3.7', '3.8', '3.9', '3.10', '3.11', '3.12', 'pypy3.7', 'pypy3.8', 'pypy3.9']
         include:
           # We may would like to introduce tests also on windows-latest on x86 (win32 wheels)?
           - os: ubuntu-latest
             architecture: 'x64'
-          - os: kivy-ubuntu-arm64
+          - os: kivy-ubuntu-22.04-arm64
             architecture: 'aarch64'
           - os: windows-latest
             architecture: 'x64'
@@ -160,7 +160,7 @@ jobs:
           brew install ant
 
       - name: Setup ant on Linux
-        if: (matrix.os == 'ubuntu-latest') || (matrix.os == 'kivy-ubuntu-arm64')
+        if: (matrix.os == 'ubuntu-latest') || (matrix.os == 'kivy-ubuntu-22.04-arm64')
         run: |
           sudo apt-get update && sudo apt-get install -y ant
 
@@ -176,7 +176,7 @@ jobs:
           python -m pip install pyjnius[dev,ci]
 
       - name: Install pyjnius wheel + test prerequisites (Linux)
-        if: matrix.os == 'ubuntu-latest' || matrix.os == 'kivy-ubuntu-arm64'
+        if: matrix.os == 'ubuntu-latest' || matrix.os == 'kivy-ubuntu-22.04-arm64'
         # --find-links=dist --no-index is needed to avoid downloading the pyjnius wheel
         # from the index. We need to test the wheel we just built.
         run: |
@@ -186,7 +186,7 @@ jobs:
           python -m pip install pyjnius[dev,ci]
 
       - name: Test wheel (Linux, macOS)
-        if: (matrix.os == 'ubuntu-latest') || (matrix.os == 'kivy-ubuntu-arm64') || (matrix.os == 'macos-latest') || (matrix.os == 'apple-silicon-m1')
+        if: (matrix.os == 'ubuntu-latest') || (matrix.os == 'kivy-ubuntu-22.04-arm64') || (matrix.os == 'macos-latest') || (matrix.os == 'apple-silicon-m1')
         run: |
           source .ci/utils.sh
           ensure_python_version ${{ matrix.python }}


### PR DESCRIPTION
`kivy-ubuntu-22.04-arm64`, is a newer scalable Ubuntu ARM64 self-hosted runner managed by us, and hosted on Azure (thanks Microsoft).