### PR TITLE
Remove support for Python 3.7 as reached EOL

### DIFF
--- a/.github/workflows/create.yml
+++ b/.github/workflows/create.yml
@@ -109,7 +109,7 @@ jobs:
     strategy:
       matrix:
         os: ['ubuntu-latest', 'macos-latest', 'windows-latest', 'kivy-ubuntu-arm64']
-        python: ['3.7', '3.8', '3.9', '3.10', '3.11', '3.12', 'pypy3.7', 'pypy3.8', 'pypy3.9']
+        python: ['3.8', '3.9', '3.10', '3.11', '3.12', 'pypy3.8', 'pypy3.9']
         include:
           # We may would like to introduce tests also on windows-latest on x86 (win32 wheels)?
           - os: ubuntu-latest
@@ -193,17 +193,8 @@ jobs:
           cd tests
           CLASSPATH=../build/test-classes:../build/classes python -m pytest -v
 
-      - name: Test wheel ( Windows + Python == 3.7.x )
-        # On Python < 3.8.x, we can't use `os.add_dll_directory`, so the jre should be in PATH.
-        if: (matrix.os == 'windows-latest') && contains(matrix.python, '3.7')
-        run: |
-          cd tests
-          $env:PATH +=";$env:JAVA_HOME\jre\bin\server\;$env:JAVA_HOME\jre\bin\client\;$env:JAVA_HOME\bin\server\"
-          $env:CLASSPATH ="../build/test-classes;../build/classes"
-          python -m pytest -v
-
-      - name: Test wheel (Windows + Python != 3.7.x )
-        if: (matrix.os == 'windows-latest') && !contains(matrix.python, '3.7')
+      - name: Test wheel (Windows)
+        if: matrix.os == 'windows-latest'
         run: |
           cd tests
           $env:CLASSPATH ="../build/test-classes;../build/classes"

--- a/.github/workflows/push-x86.yml
+++ b/.github/workflows/push-x86.yml
@@ -7,7 +7,6 @@ jobs:
     strategy:
       matrix:
         python:
-           - '3.7'
            - '3.8'
            - '3.9'
            - '3.10'

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -7,13 +7,11 @@ jobs:
     strategy:
       matrix:
         python:
-           - '3.7'
            - '3.8'
            - '3.9'
            - '3.10'
            - '3.11'
            - '3.12'
-           - 'pypy-3.7'
            - 'pypy-3.8'
            - 'pypy-3.9'
         java:
@@ -48,20 +46,13 @@ jobs:
           - os: apple-silicon-m1
             architecture: x64
           - os: apple-silicon-m1
-            python: '3.7'
-          - os: apple-silicon-m1
             python: '3.8'
           - os: apple-silicon-m1
             python: '3.9'
           - os: apple-silicon-m1
-            python: 'pypy-3.7'
-          - os: apple-silicon-m1
             python: 'pypy-3.8'
           - os: apple-silicon-m1
             python: 'pypy-3.9'
-          - os: windows-latest
-            architecture: x86
-            python: 'pypy-3.7'
           - os: windows-latest
             architecture: x86
             python: 'pypy-3.8'

--- a/setup_sdist.py
+++ b/setup_sdist.py
@@ -56,7 +56,6 @@ SETUP_KWARGS = {
         'Operating System :: Microsoft :: Windows',
         'Operating System :: POSIX :: Linux',
         'Operating System :: Android',
-        'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',


### PR DESCRIPTION
Removing Python `3.7` as reached EOL on June 27th 2023