### PR TITLE
Use specified `architecture` for CI tests instead of guessing it on `setup-python`

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -68,6 +68,7 @@ jobs:
       uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python }}
+        architecture: ${{ matrix.architecture == 'aarch64' && 'arm64' || matrix.architecture }}
 
     - name: Setup java
       uses: actions/setup-java@v4


### PR DESCRIPTION
Use specified `architecture` for CI tests instead of guessing it on `setup-python`, due to x86 tests on Windows, which happens on a x64 OS