### PR TITLE
add support to android jvm on termux

### DIFF
--- a/jnius/jnius_jvm_dlopen.pxi
+++ b/jnius/jnius_jvm_dlopen.pxi
@@ -51,6 +51,17 @@ cdef void create_jnienv() except *:
     cdef void *handle
     import jnius_config
 
+    cdef void *jnienv_pyjnius
+    handle = dlopen(b"libtermux-pyjnius.so", RTLD_LAZY)
+    if handle != NULL:
+        jnienv_pyjnius = dlsym(handle, b"get_platform_jnienv_pyjnius")
+        if jnienv_pyjnius == NULL:
+            raise SystemError("Error calling dlfcn for get_platform_jnienv_pyjnius: {0}".format(dlerror()))
+        (<void (*)(void **penv)> jnienv_pyjnius)(<void **>&_platform_default_env)
+        if _platform_default_env != NULL:
+            return
+        dlclose(handle)
+
     JAVA_LOCATION = get_java_setup()
     cdef str java_lib = JAVA_LOCATION.get_jnius_lib_location()
 


### PR DESCRIPTION
It is possible to access android classes from termux by adding new app `termux-pyjnius` which load python and pyjnius. pyjnius for termux is build with `jnius_jvm_dlopen.pxi`. It adds possibility to provide any jnienv in android. It was discussed some time ago in https://github.com/kivy/pyjnius/issues/247. It allows to use bellow example in termux.

```java
DisplayMetrics = autoclass('android.util.DisplayMetrics')

metrics = DisplayMetrics()

WindowManager = autoclass('android.view.WindowManager')
Context = autoclass('android.content.Context')
MainActivity = autoclass('com.termux.pyjnius.MainActivity')

activity = MainActivity.mActivity
window_manager = activity.getSystemService(Context.WINDOW_SERVICE)
default_display = window_manager.getDefaultDisplay()

default_display.getMetrics(metrics)

density = metrics.density
density_dpi = metrics.densityDpi
width_pixels = metrics.widthPixels
height_pixels = metrics.heightPixels

print(f"Screen density: {density}")
print(f"Screen density DPI: {density_dpi}")
print(f"Screen width in pixels: {width_pixels}")
print(f"Screen height in pixels: {height_pixels}")
```