### PR TITLE
python 3.13 (which requires cython 3) remove 3.8

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -7,11 +7,11 @@ jobs:
     strategy:
       matrix:
         python:
-           - '3.8'
            - '3.9'
            - '3.10'
            - '3.11'
            - '3.12'
+           - '3.13'
            - 'pypy-3.8'
            - 'pypy-3.9'
         java:
@@ -33,6 +33,8 @@ jobs:
           - 'x86'
           - 'aarch64'
         exclude:
+          - python: '3.13'
+            cython: '<3'
           - os: windows-latest
             architecture: aarch64
           - os: ubuntu-latest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,5 +2,6 @@
 requires = [
     "setuptools>=58.0.0",
     "wheel",
-    "Cython"
+    'Cython ; python_version < "3.13"',
+    'Cython>3 ; python_version >= "3.13"'
 ]


### PR DESCRIPTION
recent comments on #739 suggested problems building on Python 3.13; Through experimentation on GHAs, I found that Python 3.13 requires Cython 3. 

The enclosed PR forces use of Cython 3 for Python 3.13.

Thanks to @gituser789 and @white-gecko for spotting it was about Python versions.