### PR TITLE
Fix building from source failure because of Cython 3.1.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,5 +2,5 @@
 requires = [
     "setuptools>=58.0.0",
     "wheel",
-    "Cython"
+    "Cython==3.0.12"
 ]


### PR DESCRIPTION
The recent release of Cython 3.1.0 broke the building and installation of pyjnius from source