### PR TITLE
fixes for Cython 3.1 support

### DIFF
--- a/jnius/jnius_conversion.pxi
+++ b/jnius/jnius_conversion.pxi
@@ -634,6 +634,7 @@ cdef jobject convert_pyarray_to_java(JNIEnv *j_env, definition, pyarray) except 
     cdef jclass j_class
     cdef JavaObject jo
     cdef JavaClass jc
+    from ctypes import c_long as long
 
     cdef ByteArray a_bytes
 

--- a/jnius/jnius_conversion.pxi
+++ b/jnius/jnius_conversion.pxi
@@ -38,6 +38,7 @@ cdef void populate_args(JNIEnv *j_env, tuple definition_args, jvalue *j_args, ar
     cdef JavaClass jc
     cdef PythonJavaClass pc
     cdef int index
+    from ctypes import c_long as long
 
     for index, argtype in enumerate(definition_args):
         py_arg = args[index]
@@ -467,6 +468,7 @@ cdef jobject convert_python_to_jobject(JNIEnv *j_env, definition, obj) except *:
     cdef JavaClassStorage jcs
     cdef PythonJavaClass pc
     cdef int index
+    from ctypes import c_long as long
 
     if definition[0] == 'V':
         return NULL

--- a/jnius/jnius_utils.pxi
+++ b/jnius/jnius_utils.pxi
@@ -278,6 +278,7 @@ cdef int calculate_score(sign_args, args, is_varargs=False) except *:
     cdef JavaClass jc
     cdef int args_len = len(args)
     cdef int sign_args_len = len(sign_args)
+    from ctypes import c_long as long
 
     if args_len != sign_args_len and not is_varargs:
         # if the number of arguments expected is not the same

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,5 +2,5 @@
 requires = [
     "setuptools>=58.0.0",
     "wheel",
-    "Cython"
+    "Cython==3.1.0"
 ]


### PR DESCRIPTION
#752 identified that a problem existed building from Cython 3.1.0, but it was not clear from the posted errors what the problem was.

The problem appears to be that under 3.1.0 long is note defined - several error messages were observed like:
```
Error compiling Cython file:
     ------------------------------------------------------------
     ...
                 score += 10
                 continue
     
             if r == 'S' or r == 'I':
                 if isinstance(arg, int) or (
                         (isinstance(arg, long) and arg < 2147483648)):
                                          ^
     ------------------------------------------------------------

 jnius/jnius_utils.pxi:323:37: undeclared name not builtin: long
``` 

The solution is to add `from ctypes import c_long as long` where appropriate, following https://github.com/jswhit/pygrib/issues/265#issuecomment-2874812782

I think this can replace #752

