### PR TITLE
Remove support for Python 3.8 which reached EOL on 2024-10-07

### DIFF
--- a/.github/workflows/create.yml
+++ b/.github/workflows/create.yml
@@ -106,7 +106,7 @@ jobs:
     strategy:
       matrix:
         os: ['ubuntu-latest', 'macos-latest', 'windows-latest', 'kivy-ubuntu-arm64']
-        python: ['3.8', '3.9', '3.10', '3.11', '3.12', 'pypy3.8', 'pypy3.9']
+        python: ['3.9', '3.10', '3.11', '3.12', 'pypy3.9']
         include:
           # We may would like to introduce tests also on windows-latest on x86 (win32 wheels)?
           # macos-latest (ATM macos-14) runs on Apple Silicon,

--- a/.github/workflows/push-x86.yml
+++ b/.github/workflows/push-x86.yml
@@ -7,7 +7,6 @@ jobs:
     strategy:
       matrix:
         python:
-           - '3.8'
            - '3.9'
            - '3.10'
            - '3.11'

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -7,12 +7,10 @@ jobs:
     strategy:
       matrix:
         python:
-           - '3.8'
            - '3.9'
            - '3.10'
            - '3.11'
            - '3.12'
-           - 'pypy-3.8'
            - 'pypy-3.9'
         java:
           - '8'
@@ -50,9 +48,6 @@ jobs:
             architecture: x64
           - os: macos-latest
             architecture: x86
-          - os: windows-latest
-            architecture: x86
-            python: 'pypy-3.8'
           - os: windows-latest
             architecture: x86
             python: 'pypy-3.9'

--- a/setup_sdist.py
+++ b/setup_sdist.py
@@ -56,7 +56,6 @@ SETUP_KWARGS = {
         'Operating System :: Microsoft :: Windows',
         'Operating System :: POSIX :: Linux',
         'Operating System :: Android',
-        'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: 3.11',


### PR DESCRIPTION
This pull request removes support for Python 3.8 and PyPy 3.8 across the project. The changes streamline the supported Python versions in workflows, configuration files, and metadata.

Python 3.8 reached EOL on `2024-10-07`