### PR TITLE
Change `i386` test image to `bullseye` as `buster` reached `EOL`

### DIFF
--- a/.github/workflows/push-x86.yml
+++ b/.github/workflows/push-x86.yml
@@ -11,7 +11,7 @@ jobs:
            - '3.10'
            - '3.11'
     container:
-      image: i386/python:${{ matrix.python }}-buster
+      image: i386/python:${{ matrix.python }}-bullseye
     steps:
     - name: info
       run: |


### PR DESCRIPTION
This pull request updates the Python container image in the `push-x86` GitHub Actions workflow to use a more recent version of the Debian base image.

* [`.github/workflows/push-x86.yml`](diffhunk://#diff-87fe5c89a59ca615cb8132676842d0edef5facb67c089bdaf322ddace5ff6978L14-R14): Updated the container image from `buster` to `bullseye` for Python versions specified in the matrix.