### PR TITLE
Add support for Python 3.13, fix incompatible pointers (thanks to @cmacdonald)

### DIFF
--- a/.github/workflows/create.yml
+++ b/.github/workflows/create.yml
@@ -11,7 +11,7 @@ jobs:
     env:
       CIBW_BEFORE_ALL_LINUX: 'yum install -y java-11-openjdk-devel'
       CIBW_REPAIR_WHEEL_COMMAND_MACOS: ''
-      CIBW_SKIP: 'cp36-* *musllinux*'
+      CIBW_SKIP: '*musllinux*'
     strategy:
       matrix:
         include:

--- a/.github/workflows/create.yml
+++ b/.github/workflows/create.yml
@@ -56,7 +56,7 @@ jobs:
         env:
           CIBW_ARCHS: '${{ matrix.cibw_archs }}'
         run: |
-          python -m pip install cibuildwheel~=2.16.2
+          python -m pip install cibuildwheel~=3.1.1
           python -m cibuildwheel --output-dir dist
 
       - name: Install cibuildwheel & build wheels (Linux, macOS Intel)
@@ -64,7 +64,7 @@ jobs:
         env:
           CIBW_ARCHS: '${{ matrix.cibw_archs }}'
         run: |
-          python -m pip install cibuildwheel~=2.16.2
+          python -m pip install cibuildwheel~=3.1.1
           python -m cibuildwheel --output-dir dist
 
       - name: upload wheels

--- a/.github/workflows/create.yml
+++ b/.github/workflows/create.yml
@@ -106,7 +106,7 @@ jobs:
     strategy:
       matrix:
         os: ['ubuntu-latest', 'macos-latest', 'windows-latest', 'kivy-ubuntu-arm64']
-        python: ['3.9', '3.10', '3.11', '3.12', 'pypy3.9']
+        python: ['3.9', '3.10', '3.11', '3.12', '3.13', 'pypy3.9']
         include:
           # We may would like to introduce tests also on windows-latest on x86 (win32 wheels)?
           # macos-latest (ATM macos-14) runs on Apple Silicon,

--- a/jnius/jni.pxi
+++ b/jnius/jni.pxi
@@ -399,5 +399,5 @@ cdef extern from "jni.h":
         jobjectRefType (*GetObjectRefType)(JNIEnv*, jobject)
 
     ctypedef struct JNIInvokeInterface:
-        jint        (*AttachCurrentThread)(JavaVM *, JNIEnv **, void *)
+        jint        (*AttachCurrentThread)(JavaVM *, void **, void *)
         jint        (*DetachCurrentThread)(JavaVM *)

--- a/jnius/jnius_env.pxi
+++ b/jnius/jnius_env.pxi
@@ -14,10 +14,10 @@ cdef JNIEnv *get_jnienv() except NULL:
         default_env[0].GetJavaVM(default_env, &jvm)
 
     # return the current env attached to the thread
-    # XXX it threads are created from C (not java), we'll leak here.
-    cdef JNIEnv *env = NULL
+    # XXX if threads are created from C (not java), we'll leak here.
+    cdef void *env = NULL
     jvm[0].AttachCurrentThread(jvm, &env, NULL)
-    return env
+    return <JNIEnv*>env
 
 
 def detach():

--- a/setup_sdist.py
+++ b/setup_sdist.py
@@ -60,6 +60,7 @@ SETUP_KWARGS = {
         'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: 3.11',
         'Programming Language :: Python :: 3.12',
+        'Programming Language :: Python :: 3.13',
         'Topic :: Software Development :: Libraries :: Application Frameworks'
     ]
 }


### PR DESCRIPTION
This PR completes the Python 3.13 support by updating the pinned `cibuildwheel` version and advertising the availability of Python 3.13 support in docs.

However, while updating to a newer `cibuildwheel` version (which uses a different build docker image, we noticed some issues regarding incompatible pointers errors (compilers nowadays are more strict about that matter).

Thanks to @cmacdonald, some changes have been applied to have a clean build on all the build platforms.