### PR TITLE
Remove support for `Cython` versions prior to `3.x.x`

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -24,16 +24,12 @@ jobs:
           - 'windows-latest'
           - 'macos-latest'
           - 'macos-13'
-        cython:
-          - '<3'
-          - '>=3'
         architecture:
           - 'x64'
           - 'x86'
           - 'aarch64'
         exclude:
           - python: '3.13'
-            cython: '<3'
           - os: windows-latest
             architecture: aarch64
           - os: ubuntu-latest
@@ -90,16 +86,6 @@ jobs:
 
     - name: Build test classes via ant
       run: ant all
-
-    - name: (Windows) Force Cython version
-      # Windows sed doesnt accept .bak filename extensions
-      if: matrix.os == 'windows-latest'
-      run: sed -i 's/"Cython"/"Cython${{matrix.cython}}"/' pyproject.toml
-    
-    - name: (Linux, macOS) Force Cython version
-      # macOS sed requires .bak filename extensions
-      if: (matrix.os == 'ubuntu-latest') || (matrix.os == 'macos-latest') || (matrix.os == 'macos-13')
-      run: sed -i.bak 's/"Cython"/"Cython${{matrix.cython}}"/' pyproject.toml
 
     - name: Install pyjnius with [dev, ci] extras
       run: |

--- a/jnius/jnius.pyx
+++ b/jnius/jnius.pyx
@@ -108,7 +108,7 @@ ELSE:
 
 # from Cython 3.0, in the MetaJavaClass, this is accessed as _JavaClass__cls_storage
 # see https://cython.readthedocs.io/en/latest/src/userguide/migrating_to_cy30.html#class-private-name-mangling
-cdef CLS_STORAGE_NAME = '_JavaClass__cls_storage' if JNIUS_CYTHON_3 else '__cls_storage'
+cdef CLS_STORAGE_NAME = '_JavaClass__cls_storage'
 
 include "jnius_env.pxi"
 include "jnius_utils.pxi"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,6 +2,5 @@
 requires = [
     "setuptools>=58.0.0",
     "wheel",
-    'Cython ; python_version < "3.13"',
-    'Cython>3 ; python_version >= "3.13"'
+    "Cython~=3.1.2",
 ]

--- a/setup.py
+++ b/setup.py
@@ -86,14 +86,7 @@ compile_native_invocation_handler(JAVA)
 
 # generate the config.pxi
 with open(join(dirname(__file__), 'jnius', 'config.pxi'), 'w') as fd:
-    if PLATFORM == 'android':
-        cython3 = environ.get('ANDROID_PYJNIUS_CYTHON_3', '0') == '1'
-    else:
-        import Cython
-        cython3 = Cython.__version__.startswith('3.')
     fd.write('DEF JNIUS_PLATFORM = {0!r}\n\n'.format(PLATFORM))
-    # record the Cython version, to address #669
-    fd.write(f'DEF JNIUS_CYTHON_3 = {cython3}')
 
 # pop setup.py from included files in the installed package
 SETUP_KWARGS['py_modules'].remove('setup')


### PR DESCRIPTION
This pull request simplifies the build process by removing conditional logic for Cython versioning and standardizing the required dependencies. The key changes involve removing Cython version-specific configurations, updating dependency specifications, and cleaning up related code.