### PR TITLE
Fix all Cython conditional keywords

### DIFF
--- a/jnius/jnius.pyx
+++ b/jnius/jnius.pyx
@@ -99,11 +99,11 @@ include "jnius_compat.pxi"
 include "jni.pxi"
 include "config.pxi"
 
-if JNIUS_PLATFORM == "android":
+IF JNIUS_PLATFORM == "android":
     include "jnius_jvm_android.pxi"
-elif JNIUS_PLATFORM == "win32":
+ELIF JNIUS_PLATFORM == "win32":
     include "jnius_jvm_desktop.pxi"
-else:
+ELSE:
     include "jnius_jvm_dlopen.pxi"
 
 # from Cython 3.0, in the MetaJavaClass, this is accessed as _JavaClass__cls_storage

--- a/jnius/jnius.pyx
+++ b/jnius/jnius.pyx
@@ -99,11 +99,11 @@ include "jnius_compat.pxi"
 include "jni.pxi"
 include "config.pxi"
 
-IF JNIUS_PLATFORM == "android":
+if JNIUS_PLATFORM == "android":
     include "jnius_jvm_android.pxi"
-ELIF JNIUS_PLATFORM == "win32":
+elif JNIUS_PLATFORM == "win32":
     include "jnius_jvm_desktop.pxi"
-ELSE:
+else:
     include "jnius_jvm_dlopen.pxi"
 
 # from Cython 3.0, in the MetaJavaClass, this is accessed as _JavaClass__cls_storage

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
 requires = [
-    "setuptools>=58.0.0",
+    "setuptools==80.9.0",
     "wheel",
     "Cython~=3.1.3",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,5 +2,5 @@
 requires = [
     "setuptools>=58.0.0",
     "wheel",
-    "Cython~=3.1.2",
+    "Cython~=3.1.3",
 ]


### PR DESCRIPTION
- Replace IF with if, ELIF with elif, and ELSE with else
- Ensures proper inclusion of platform-specific .pxi files
- Prevents build errors due to invalid Cython syntax