### PR TITLE
Update testhardware/main.py to python3 syntax

### DIFF
--- a/tests/android/testhardware/main.py
+++ b/tests/android/testhardware/main.py
@@ -1,14 +1,14 @@
 from time import sleep
 from jnius import autoclass
 
-print '-- test hardware start!'
+print('-- test hardware start!')
 
 Hardware = autoclass('org.renpy.android.Hardware')
-print 'DPI is', Hardware.getDPI()
+print('DPI is', Hardware.getDPI())
 
 Hardware.accelerometerEnable(True)
 for x in xrange(20):
     print Hardware.accelerometerReading()
     sleep(.1)
 
-print '-- test hardware done!'
+print('-- test hardware done!')


### PR DESCRIPTION
When running a build for android, I found these python2 print statements breaking the build.