### PR TITLE
Use latest release for `action-gh-release`

### DIFF
--- a/.github/workflows/create.yml
+++ b/.github/workflows/create.yml
@@ -209,7 +209,7 @@ jobs:
     - name: Upload Test Release Asset
       id: create_test_release
       if: startsWith(github.ref, 'refs/tags/') && endsWith(github.ref, '-test')
-      uses: softprops/action-gh-release@78c309ef59fdb9557cd6574f2e0be552936ed728
+      uses: softprops/action-gh-release@v2.3.2
       with:
         prerelease: true
         files: |
@@ -222,7 +222,7 @@ jobs:
     - name: Upload Release Asset
       id: upload-release-asset
       if: startsWith(github.ref, 'refs/tags/') && ! endsWith(github.ref, '-test')
-      uses: softprops/action-gh-release@78c309ef59fdb9557cd6574f2e0be552936ed728
+      uses: softprops/action-gh-release@v2.3.2
       with:
         files: |
           dist/*.whl


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow to use a newer version of the `softprops/action-gh-release` action for both test and production release asset uploads. This change helps ensure the workflow uses the latest features and bug fixes from the action.
