### PR TITLE
Use `merge-multiple: true` when downloading artifacts for release

### DIFF
--- a/.github/workflows/create.yml
+++ b/.github/workflows/create.yml
@@ -205,6 +205,7 @@ jobs:
       with:
         pattern: wheels-*
         path: dist
+        merge-multiple: true
 
     - name: Upload Test Release Asset
       id: create_test_release


### PR DESCRIPTION
Added the `merge-multiple: true` option to the asset upload step in `.github/workflows/create.yml` to ensure that multiple matching assets are merged into a single folder.