### PR TITLE
Android: SDL-agnostic, redistributable PEP 738 wheel

### DIFF
--- a/.github/workflows/android-wheels.yml
+++ b/.github/workflows/android-wheels.yml
@@ -1,0 +1,107 @@
+name: Android wheels
+
+# Builds redistributable PEP 738 Android wheels (android_*) for pyjnius via
+# cibuildwheel, and (on a GitHub release) publishes them to PyPI using trusted
+# publishing (OIDC). Desktop wheels/sdist are handled by the existing CI; this
+# workflow is additive and Android-only.
+#
+# The wheel is SDL-agnostic and Java-free: it resolves the JNIEnv at runtime and
+# ships no Java. See docs/source/android-wheel.rst for the runtime/Java-glue
+# contract that the host app (packager) must satisfy.
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - "jnius/**"
+      - "jnius_config/**"
+      - "setup.py"
+      - "setup_sdist.py"
+      - "pyproject.toml"
+      - ".github/workflows/android-wheels.yml"
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: Build + test (${{ matrix.python }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        # cibuildwheel builds every ABI in [tool.cibuildwheel.android].archs
+        # (arm64_v8a ships; x86_64 is the on-device-testable ABI) for each
+        # selected CPython. 3.15 is pre-release until Oct 2026 (see CIBW_ENABLE).
+        python: ["cp313", "cp314"]
+    steps:
+      - uses: actions/checkout@v4
+
+      # Host interpreter that runs cibuildwheel (not the target). cibuildwheel
+      # downloads the target CPython Android runtime itself.
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+
+      # The x86_64 testbed boots a Gradle-managed emulator, which needs KVM.
+      # GitHub's Linux runners expose /dev/kvm; widen its permissions so the
+      # emulator can use it. arm64_v8a builds but skips on-device tests (the
+      # runner is x86_64).
+      - name: Enable KVM
+        run: |
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' \
+            | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
+
+      # On Android, setup.py compiles a pre-generated jnius.c (Cython is a
+      # build-only tool, not needed on the target), so it must exist before the
+      # build. It is arch-independent -- one .c serves both ABIs. config.pxi must
+      # select the android include branch at cythonize time.
+      - name: Pre-generate jnius.c (Android compiles the .c, not the .pyx)
+        run: |
+          python -m pip install "Cython~=3.1.2"
+          printf "DEF JNIUS_PLATFORM = 'android'\n" > jnius/config.pxi
+          cython -3 jnius/jnius.pyx -o jnius/jnius.c
+
+      # Pin the cibuildwheel action to the same version pinned in
+      # pyproject.toml's toolchain comment: cibuildwheel selects the NDK, so this
+      # pin (plus the explicit -Wl,-z,max-page-size=16384 in pyproject) fixes the
+      # produced ABI/alignment. ubuntu-latest ships the Android SDK (ANDROID_HOME);
+      # cibuildwheel installs the matching NDK via sdkmanager. A fresh checkout has
+      # no stale build/ dir, so the Java-free prune in setup.py is reliable here
+      # (locally you must `rm -rf build` first -- see docs/source/android-wheel.rst).
+      - name: Build Android wheels
+        uses: pypa/cibuildwheel@v4.1.0
+        env:
+          CIBW_PLATFORM: android
+          CIBW_BUILD: "${{ matrix.python }}-android_*"
+          CIBW_ENABLE: cpython-prerelease
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: android-wheels-${{ matrix.python }}
+          path: ./wheelhouse/*.whl
+          if-no-files-found: error
+
+  publish:
+    name: Publish to PyPI
+    needs: build
+    if: github.event_name == 'release' && github.event.action == 'published'
+    runs-on: ubuntu-latest
+    # Requires a PyPI trusted publisher configured for this repo + environment.
+    # Maintainer action: https://docs.pypi.org/trusted-publishers/
+    environment: pypi
+    permissions:
+      id-token: write   # OIDC token for trusted publishing
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          pattern: android-wheels-*
+          path: dist
+          merge-multiple: true
+      - uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: dist

--- a/docs/source/android-wheel.rst
+++ b/docs/source/android-wheel.rst
@@ -1,0 +1,113 @@
+.. _android-wheel:
+
+Android wheels
+==============
+
+PyJNIus can be published as a prebuilt `PEP 738 <https://peps.python.org/pep-0738/>`_
+Android wheel (``android_*`` tags), so an Android packager can ``pip install``
+it instead of compiling from source per app. The wheel is **SDL-agnostic** and
+**Java-free**: it resolves the JVM ``JNIEnv`` at runtime and ships no Java. In
+return, the host application must satisfy a small runtime contract (below).
+
+.. note::
+   This describes the *redistributable* wheel. On desktop, PyJNIus still starts
+   its own JVM and bundles the compiled ``NativeInvocationHandler.class`` as
+   before; nothing here changes desktop behavior.
+
+
+The runtime contract
+--------------------
+
+The wheel does **not** create a JVM on Android; it attaches to the one the host
+process already has. A conforming host must provide:
+
+1. **An in-process JVM discoverable at import.** The ``JNIEnv`` is resolved at
+   the first ``import jnius`` in this order:
+
+   * ``SDL_GetAndroidJNIEnv`` from ``libSDL3.so`` (SDL3), else
+   * ``SDL_AndroidGetJNIEnv`` from ``libSDL2.so`` (SDL2), else
+   * ``JNI_GetCreatedJavaVMs`` from ``libnativehelper.so`` (SDL-independent,
+     **API 31+ only**) + ``AttachCurrentThread``.
+
+   For an SDL host, its SDL library must be **loaded before the first**
+   ``import jnius`` (a Kivy/SDL app loads SDL at startup, which captures the
+   ``JavaVM`` via SDL's own ``JNI_OnLoad``). Each tier tries
+   ``dlsym(RTLD_DEFAULT, ...)`` first, then ``dlopen``\ s the library by soname
+   and resolves the symbol from that handle -- a CPython extension imported via
+   ``dlopen`` does not have the host's ``System.loadLibrary``\ 'd SDL in its
+   default lookup scope. No ``DT_NEEDED`` on any ``libSDL``/``libnativehelper``
+   is created, so the wheel loads regardless of which (if any) SDL is present.
+
+2. **The Java glue on the app's dex classpath.** PyJNIus's
+   *Python-implements-a-Java-interface* feature
+   (``PythonJavaClass``/``@java_method``) needs the class
+   ``org.jnius.NativeInvocationHandler``. A ``.whl`` carries no ``.dex`` and a
+   class in ``site-packages`` is **not** on ART's classpath, so the wheel does
+   not and cannot deliver it. The packager (bootstrap/build system) must compile
+   and dex ``org.jnius.NativeInvocationHandler`` into the APK. Plain ``autoclass``
+   and method calls need no glue; only proxies do.
+
+   .. warning::
+      **Matched-pair coupling.** The wheel's native ``invoke0`` contract (bound
+      at runtime via ``RegisterNatives``) and the packager's copy of
+      ``NativeInvocationHandler.java`` must be updated together. Nothing enforces
+      this once the glue is out of the wheel -- a mismatch surfaces as a
+      ``ClassNotFound``/``NoSuchMethod`` at first proxy creation. The canonical
+      source lives in the PyJNIus repository at
+      ``jnius/src/org/jnius/NativeInvocationHandler.java``.
+
+If no JVM/glue is found, the first ``import jnius`` raises a clear
+``RuntimeError`` naming the missing getter, rather than a cryptic dlopen/symbol
+failure.
+
+
+Building the wheel
+------------------
+
+Build on a Linux ``x86_64`` (WSL2 counts) or macOS host with an Android SDK;
+`cibuildwheel <https://cibuildwheel.pypa.io/en/stable/platforms/#android>`_
+drives the NDK via ``sdkmanager``. The pinned toolchain lives in
+``[tool.cibuildwheel.android]`` in ``pyproject.toml``.
+
+.. code:: bash
+
+    # 1. Android compiles a *pre-generated* jnius.c (Cython is build-only and not
+    #    needed on the target). config.pxi selects the android include branch.
+    printf "DEF JNIUS_PLATFORM = 'android'\n" > jnius/config.pxi
+    cython -3 jnius/jnius.pyx -o jnius/jnius.c
+
+    # 2. Build from a CLEAN tree. `python -m build --no-isolation` reuses
+    #    build/lib.android-*; a stale one from an earlier build re-injects the
+    #    Java payload and breaks the Java-free guarantee. A fresh checkout (CI) is
+    #    already clean.
+    rm -rf build
+
+    # 3. arm64_v8a ships to devices; x86_64 is the testability ABI (cibuildwheel's
+    #    emulator testbed only runs the build-host arch).
+    cibuildwheel --only cp314-android_arm64_v8a --output-dir wheelhouse
+    cibuildwheel --only cp314-android_x86_64    --output-dir wheelhouse
+
+The frontend must be ``build``/``uv`` (Android does not support the ``pip``
+frontend); this is set in ``pyproject.toml``. CPython 3.15 (pre-release until
+Oct 2026) additionally needs ``--enable cpython-prerelease``.
+
+**16 KB page alignment.** Android 15/16 requires native ``.so``\ s to have
+16 KB-aligned LOAD segments. The build pins
+``LDFLAGS = "-Wl,-z,max-page-size=16384"`` in ``[tool.cibuildwheel.android]`` so
+the wheel is 16 KB-aligned independent of the NDK's default. This aligns only
+PyJNIus's ``.so`` -- the packager is responsible for aligning the bootstrap libs
+(SDL, libpython, ...) and for 16 KB zip-aligning the final APK.
+
+
+Verifying a built wheel
+----------------------
+
+.. code:: bash
+
+    # unzip the wheel, then, with the NDK's llvm-readelf:
+    llvm-readelf -d jnius/jnius*.so | grep NEEDED     # no libSDL / libnativehelper / libart
+    llvm-readelf -l jnius/jnius*.so | grep LOAD       # Align column == 0x4000 (16 KB)
+    llvm-readelf --dyn-syms jnius/jnius*.so | grep -E 'dlopen|dlsym'   # runtime-resolved
+
+The wheel should contain only the ``.so`` and the Python modules -- no
+``src/org``, ``.java`` or ``.class``.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -30,6 +30,7 @@ documentation.
    installation
    quickstart
    android
+   android-wheel
    api
    packaging
    contact

--- a/jnius/jnius_jvm_android.pxi
+++ b/jnius/jnius_jvm_android.pxi
@@ -1,6 +1,162 @@
-# on android, rely on SDL to get the JNI env
-cdef extern JNIEnv *SDL_AndroidGetJNIEnv()
+# On Android, pyjnius obtains the JVM's JNIEnv from the host process rather than
+# creating a JVM itself. Historically this was a *link-time* dependency on SDL2
+# (``-lSDL2`` plus a direct reference to ``SDL_AndroidGetJNIEnv``), which
+# (a) hard-linked the wheel to one SDL generation and (b) is incompatible with a
+# redistributable PEP 738 wheel built with no host app present.
+#
+# Instead we resolve the env at *runtime*, in order of preference:
+#
+#   1. SDL_GetAndroidJNIEnv  from libSDL3.so  -- SDL3 (primary; all API levels)
+#   2. SDL_AndroidGetJNIEnv  from libSDL2.so  -- SDL2 (primary; all API levels)
+#   3. JNI_GetCreatedJavaVMs from libnativehelper.so -- SDL-independent, API 31+
+#
+# Tiers 1-2 are the primary path and work on every supported API level: a Kivy/SDL
+# host loads its SDL library via System.loadLibrary before ``import jnius``, so
+# SDL's own JNI_OnLoad has captured the JavaVM, and SDL re-exposes it as the getter
+# we resolve here. This is the only viable mechanism for a *dlopen'd* CPython
+# extension (see the JNI_OnLoad note below).
+#
+# How the getter is resolved matters. EMPIRICAL FINDING (p4a SDL2 host, API 32):
+# dlsym(RTLD_DEFAULT, "SDL_AndroidGetJNIEnv") returns NULL even though libSDL2.so
+# is loaded and exports it -- this .so is a CPython extension dlopen'd from
+# site-packages, and the host's System.loadLibrary'd SDL is NOT in its default
+# lookup scope. So each tier tries RTLD_DEFAULT first, then dlopen's the library by
+# soname (libSDL3.so / libSDL2.so / libnativehelper.so -- all already resident in
+# the app linker namespace, so dlopen just returns a handle) and dlsym's that
+# handle. dlopen keeps everything runtime-only: no DT_NEEDED on any of them. This
+# is the same fix tier 3 needed for libnativehelper (see below).
+#
+# Tier 3 is a *best-effort* fallback for non-SDL hosts (and cibuildwheel's SDL-less
+# testbed). JNI_GetCreatedJavaVMs became a public libnativehelper export only in
+# Android 12 / API 31 ("introduced=S"). EMPIRICAL FINDING (cibuildwheel testbed,
+# API 35): dlsym(RTLD_DEFAULT, "JNI_GetCreatedJavaVMs") still returns NULL even at
+# API 31+, because libnativehelper is not in this extension's default lookup scope.
+# The working approach is to dlopen("libnativehelper.so") by soname (permitted for
+# apps on API 31+ as a public NDK library) and dlsym the returned handle -- done in
+# _resolve_get_created_javavms() below. Verified on-device: autoclass round-trips
+# through ART this way (vm.name=Dalvik). On API 24-30 the library is not app-
+# accessible, so a non-SDL host there falls through to the clear RuntimeError; that
+# is acceptable because the SDL path (tiers 1-2) already covers the real target.
+#
+# Why NOT JNI_OnLoad(JavaVM*, void*)?  It is the officially-blessed, all-API way to
+# receive the JavaVM -- BUT Android only calls it for libraries loaded via Java's
+# System.loadLibrary() (ART's LoadNativeLibrary does dlopen + dlsym("JNI_OnLoad")).
+# This .so is a CPython extension imported via a plain dlopen(), so ART never calls
+# a JNI_OnLoad defined here -- it would be dead code. The host's System.loadLibrary'd
+# libs (e.g. SDL) are where JNI_OnLoad legitimately fires; we consume the result of
+# theirs via the getters above. A truly SDL-independent, all-API path would require
+# the host to hand us the VM explicitly (an explicit runtime-contract setter), not autodetection.
+#
+# Every symbol here is resolved with dlsym and NONE is linked: the NDK links with
+# ``-Wl,--no-undefined``, so a leftover undefined reference (SDL or JNI) would
+# fail the link. dlsym keeps the reference dynamic, resolved against whatever the
+# host process provides.
+
+cdef extern from "dlfcn.h" nogil:
+    void *dlopen(const char *filename, int flag)
+    void *dlsym(void *handle, const char *symbol)
+    void *RTLD_DEFAULT
+    int RTLD_NOW
+
+ctypedef JNIEnv *(*_sdl_get_jnienv_t)() noexcept nogil
+ctypedef jint (*_get_created_javavms_t)(JavaVM **, jsize, jsize *) noexcept nogil
+
+
+cdef void *_resolve_get_created_javavms():
+    # JNI_GetCreatedJavaVMs lives in libnativehelper.so (a public NDK library
+    # since API 31 / Android 12). Being a *public* export means it can be linked
+    # or dlopen'd by soname -- it does NOT mean RTLD_DEFAULT reaches it, because
+    # libnativehelper is not in this extension's default lookup scope. Empirically
+    # (cibuildwheel testbed, API 35) the RTLD_DEFAULT lookup returns NULL, so we
+    # explicitly dlopen the public library by name (allowed for apps on API 31+)
+    # and dlsym its handle. dlopen keeps this runtime-only: no DT_NEEDED, so the
+    # wheel still loads on hosts/levels where the library is absent.
+    cdef void *sym = dlsym(RTLD_DEFAULT, b"JNI_GetCreatedJavaVMs")
+    if sym != NULL:
+        return sym
+
+    cdef void *handle = dlopen(b"libnativehelper.so", RTLD_NOW)
+    if handle != NULL:
+        sym = dlsym(handle, b"JNI_GetCreatedJavaVMs")
+        if sym != NULL:
+            return sym
+
+    # Older/alternate runtimes exported it from libart.so; try that too.
+    handle = dlopen(b"libart.so", RTLD_NOW)
+    if handle != NULL:
+        sym = dlsym(handle, b"JNI_GetCreatedJavaVMs")
+        if sym != NULL:
+            return sym
+
+    return NULL
+
+
+cdef void *_resolve_sdl_getter(const char *name, const char *soname):
+    # Resolve an SDL JNIEnv getter by symbol name. EMPIRICAL FINDING (p4a SDL2
+    # host, API 32): dlsym(RTLD_DEFAULT, "SDL_AndroidGetJNIEnv") returns NULL even
+    # though libSDL2.so is resident -- a CPython extension dlopen'd from
+    # site-packages does not have the host's System.loadLibrary'd SDL in its
+    # default lookup scope. So try RTLD_DEFAULT first (works where SDL is global),
+    # then dlopen the SDL soname by name (already loaded in the app linker
+    # namespace; dlopen just returns a handle + refcount) and dlsym that handle.
+    # dlopen keeps this runtime-only: no DT_NEEDED on any libSDL.
+    cdef void *sym = dlsym(RTLD_DEFAULT, name)
+    if sym != NULL:
+        return sym
+    cdef void *handle = dlopen(soname, RTLD_NOW)
+    if handle != NULL:
+        return dlsym(handle, name)
+    return NULL
+
+
+cdef JNIEnv *_jnienv_from_sdl():
+    # SDL3 renamed the getter (SDL_AndroidGetJNIEnv -> SDL_GetAndroidJNIEnv); try
+    # SDL3 first, then SDL2. Returns NULL if neither getter is in the process.
+    cdef void *sym = _resolve_sdl_getter(b"SDL_GetAndroidJNIEnv", b"libSDL3.so")
+    if sym != NULL:
+        return (<_sdl_get_jnienv_t>sym)()
+    sym = _resolve_sdl_getter(b"SDL_AndroidGetJNIEnv", b"libSDL2.so")
+    if sym != NULL:
+        return (<_sdl_get_jnienv_t>sym)()
+    return NULL
+
+
+cdef JNIEnv *_jnienv_from_created_vm():
+    # SDL-independent, best-effort path. JNI_GetCreatedJavaVMs is a public
+    # libnativehelper export only on API 31+ (Android 12); on API 24-30 this
+    # dlsym typically returns NULL (the symbol is outside the app linker
+    # namespace) and we return NULL so the caller falls through to a clear
+    # error. Where it does resolve, it yields the process' existing JavaVM and
+    # we attach the current thread to obtain its JNIEnv. Returns NULL if the
+    # symbol is absent, no VM has been created, or the attach fails.
+    cdef void *sym = _resolve_get_created_javavms()
+    if sym == NULL:
+        return NULL
+
+    cdef JavaVM *vm = NULL
+    cdef jsize n_vms = 0
+    if (<_get_created_javavms_t>sym)(&vm, 1, &n_vms) != 0 or n_vms < 1 or vm == NULL:
+        return NULL
+
+    cdef void *env = NULL
+    if vm[0].AttachCurrentThread(vm, &env, NULL) != 0:
+        return NULL
+    return <JNIEnv*>env
 
 
 cdef JNIEnv *get_platform_jnienv() except NULL:
-    return <JNIEnv*>SDL_AndroidGetJNIEnv()
+    cdef JNIEnv *env = _jnienv_from_sdl()
+    if env == NULL:
+        env = _jnienv_from_created_vm()
+
+    if env != NULL:
+        return env
+
+    raise RuntimeError(
+        "pyjnius (Android) could not obtain a JNIEnv: no SDL JNIEnv getter "
+        "(SDL_GetAndroidJNIEnv / SDL_AndroidGetJNIEnv) and no in-process JVM "
+        "(JNI_GetCreatedJavaVMs) were found in the process. The host must "
+        "provide an in-process JVM before the first 'import jnius' -- e.g. a "
+        "Kivy/SDL app loads its SDL library (libSDL3.so or libSDL2.so) with "
+        "global symbol visibility, which exposes the SDL getter."
+    )

--- a/jnius_config/env.py
+++ b/jnius_config/env.py
@@ -297,7 +297,11 @@ class MacOsXJavaLocation(UnixJavaLocation):
 
 class AndroidJavaLocation(UnixJavaLocation):
     def get_libraries(self):
-        return ['SDL2', 'log']
+        # Do NOT hard-link any specific SDL generation: a DT_NEEDED on
+        # libSDL2.so/libSDL3.so would lock the wheel to one SDL/Kivy generation
+        # and fail to dlopen against the other. The JNIEnv getter is resolved at
+        # runtime instead (see jnius_jvm_android.pxi); only liblog is needed.
+        return ['log']
 
     def get_include_dirs(self):
         # When cross-compiling for Android, we should not use the include dirs

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,3 +4,52 @@ requires = [
     "wheel",
     "Cython~=3.1.2",
 ]
+
+# --- Android wheel build -----------------------------------------------------
+# Reproducible cibuildwheel configuration for the redistributable, SDL-agnostic
+# Android wheel. All keys are scoped to the `android` subsection so desktop
+# builds are unaffected.
+#
+# Toolchain pins (the inputs that determine the produced wheel):
+#   * cibuildwheel : 4.1.0  -- pins the NDK it installs via sdkmanager.
+#     cibuildwheel has no NDK-version key; the NDK is a function of the
+#     cibuildwheel version, so pin cibuildwheel to pin the NDK.
+#   * NDK          : 27.3.13750724  (installed by cibuildwheel 4.1.0)
+#   * Cython       : ~=3.1.2  (build-only; see [build-system] above)
+#
+# Invocation (ABI is selected per run; only the build-host arch is testable):
+#   uvx --from "Cython~=3.1.2" cython -3 jnius/jnius.pyx -o jnius/jnius.c
+#   cibuildwheel --only cp314-android_x86_64    --output-dir ~/wheelhouse
+#   cibuildwheel --only cp314-android_arm64_v8a --output-dir ~/wheelhouse
+#
+# CPython 3.15 (final Oct 2026) additionally needs `--enable cpython-prerelease`
+# on the command line; the 3.14 config below is unchanged for it.
+[tool.cibuildwheel.android]
+# Android does not support the `pip` build frontend.
+build-frontend = "build"
+
+# The two target ABIs: arm64_v8a ships to devices; x86_64 is the testability ABI
+# (cibuildwheel's emulator testbed only runs the build-host architecture).
+archs = ["arm64_v8a", "x86_64"]
+
+# ANDROID_API_LEVEL: minimum supported API level baked into the wheel tag
+#   (-> android_24_*). 24 is the first level with RUNPATH (required by auditwheel to
+#   graft external .so's) and covers ~99% of active devices.
+# LDFLAGS -Wl,-z,max-page-size=16384: force 16 KB-aligned ELF LOAD segments, required
+#   to load on Android 15/16 (16 KB-page) devices. This is deliberate reproducibility
+#   policy, not a workaround: NDK r27 (pinned above) does NOT 16 KB-align by default
+#   (verified: the same r27 clang emits 4 KB under a bare build); the wheel's 16 KB
+#   today rides on CPython-Android's implicit LDFLAGS. Setting it here makes alignment
+#   independent of the NDK version and of CPython's build flags. NOTE: this aligns only
+#   this extension's .so -- bootstrap libs (SDL/python/main) and final APK zip-alignment
+#   are the app packager's responsibility.
+environment = { ANDROID_API_LEVEL = "24", LDFLAGS = "-Wl,-z,max-page-size=16384" }
+
+# On-device smoke test. cibuildwheel installs the wheel and runs this in its
+# Android testbed on an emulator (only the build-host arch, x86_64, is tested;
+# arm64_v8a builds but skips on-device tests). The testbed has NO SDL loaded, so a
+# successful autoclass here specifically exercises the tier-3 JNI_GetCreatedJavaVMs
+# fallback (tiers 1-2 dlsym would return NULL without SDL). The default emulator is
+# `--managed maxVersion` (API >= 31), where that symbol is a public export.
+# Android can't run shell scripts, so this must be a `python -c`/`-m` command.
+test-command = "python -c 'import jnius; from jnius import autoclass; S = autoclass(\"java.lang.System\"); vm = S.getProperty(\"java.vm.name\"); vendor = S.getProperty(\"java.vendor\"); ver = S.getProperty(\"java.version\"); assert vm, \"no java.vm.name (JNI round-trip failed)\"; print(\"ANDROID_SMOKE_OK vm.name=%s vendor=%s java.version=%s\" % (vm, vendor, ver))'"

--- a/setup.py
+++ b/setup.py
@@ -61,7 +61,14 @@ if PLATFORM == 'android':
 
 JAVA=get_java_setup(PLATFORM)
 
-assert JAVA.is_jdk(), "You need a JDK, we only found a JRE. Try setting JAVA_HOME"
+# The Android wheel is Java-free: the org.jnius.NativeInvocationHandler glue is
+# supplied and dex'd by the host app (e.g. a Kivy/kivyforge bootstrap), never by the
+# wheel -- a class in site-packages is not on ART's dex classpath, so a bundled
+# .class/.java would be inert. Android therefore needs no javac/JDK and ships no Java
+# (see the package_data prune below). Desktop is unchanged: it still requires a JDK to
+# compile and bundle NativeInvocationHandler.class, which its self-hosted JVM loads.
+if PLATFORM != 'android':
+    assert JAVA.is_jdk(), "You need a JDK, we only found a JRE. Try setting JAVA_HOME"
 
 
 def compile_native_invocation_handler(java):
@@ -80,7 +87,8 @@ def compile_native_invocation_handler(java):
         ])
 
 
-compile_native_invocation_handler(JAVA)
+if PLATFORM != 'android':
+    compile_native_invocation_handler(JAVA)
 
 
 # generate the config.pxi
@@ -89,6 +97,15 @@ with open(join(dirname(__file__), 'jnius', 'config.pxi'), 'w') as fd:
 
 # pop setup.py from included files in the installed package
 SETUP_KWARGS['py_modules'].remove('setup')
+
+# Make the Android wheel truly Java-free: drop the org.jnius glue from package_data so
+# neither the .java source nor a .class ships (it would be inert on Android anyway).
+# The canonical source stays in the repo/sdist for any packager that needs it.
+if PLATFORM == 'android':
+    SETUP_KWARGS['package_data'] = {
+        pkg: [p for p in patterns if not p.startswith('src/org')]
+        for pkg, patterns in SETUP_KWARGS.get('package_data', {}).items()
+    }
 
 ext_modules = [
     Extension(


### PR DESCRIPTION
## Summary

Today pyjnius on Android must be **compiled from source per app** and is
**hard-linked against a specific SDL** (`-lSDL2`, with a direct reference to
`SDL_AndroidGetJNIEnv`) to obtain its `JNIEnv`. That prevents shipping a single
prebuilt Android wheel and locks pyjnius to one SDL generation.

This PR makes pyjnius buildable as **one redistributable
[PEP 738](https://peps.python.org/pep-0738/) Android wheel** (`android_*` tags)
that works regardless of the host, by resolving the `JNIEnv` **at runtime** with
**no link-time dependency on SDL**. It also wires up a `cibuildwheel` build/test
matrix and (on release) PyPI publishing.

Desktop behavior is unchanged.

## What changed

- **`jnius/jnius_jvm_android.pxi`** — replace the single linked
  `SDL_AndroidGetJNIEnv()` call with a runtime resolver, tried in order:
  1. `SDL_GetAndroidJNIEnv` from `libSDL3.so` (SDL3)
  2. `SDL_AndroidGetJNIEnv` from `libSDL2.so` (SDL2)
  3. `JNI_GetCreatedJavaVMs` from `libnativehelper.so` (SDL-independent, **API 31+**) + `AttachCurrentThread`

  Each tier tries `dlsym(RTLD_DEFAULT, …)` first, then `dlopen`s the library by
  soname and `dlsym`s that handle. Nothing is linked, so the `.so` has **no
  `DT_NEEDED` on any `libSDL`/`libnativehelper`**. If none resolves, the first
  `import jnius` raises a clear `RuntimeError` explaining the host contract.
- **`jnius_config/env.py`** — `AndroidJavaLocation.get_libraries()` drops `'SDL2'`
  → returns `['log']` (no SDL at link time).
- **`setup.py`** — on Android only: skip the `javac`/JDK requirement and exclude
  `src/org/jnius/*` from `package_data`, so the wheel is **Java-free**. (Desktop
  still compiles and bundles `NativeInvocationHandler.class` as before.)
- **`pyproject.toml`** — `[tool.cibuildwheel.android]`: pinned build frontend,
  ABIs (`arm64_v8a`, `x86_64`), API level (24), `LDFLAGS=-Wl,-z,max-page-size=16384`
  (16 KB page alignment for Android 15/16), and an on-device smoke test.
- **`.github/workflows/android-wheels.yml`** — `cibuildwheel` build+test matrix
  with a release-triggered PyPI trusted-publishing job.
- **`docs/source/android-wheel.rst`** — the runtime + Java-glue contract, build
  steps, and verification commands.

## Design notes

- **Why not `JNI_OnLoad`?** It is the all-API, officially-blessed way to receive
  the `JavaVM`, but Android only calls it for libraries loaded via
  `System.loadLibrary()`. This `.so` is a CPython extension imported via a plain
  `dlopen()`, so ART never calls a `JNI_OnLoad` defined here — it would be dead
  code. We instead consume the `JavaVM` that the host's own
  `System.loadLibrary`'d libs (e.g. SDL) captured in *their* `JNI_OnLoad`.
- **Why `dlopen(soname)` and not just `RTLD_DEFAULT`?** Empirically, a CPython
  extension `dlopen`'d from site-packages does **not** have the host's
  `System.loadLibrary`'d SDL (nor `libnativehelper`) in its default lookup scope:
  `dlsym(RTLD_DEFAULT, "SDL_AndroidGetJNIEnv")` returns `NULL` on a real SDL2 host
  (API 32), and `dlsym(RTLD_DEFAULT, "JNI_GetCreatedJavaVMs")` returns `NULL` even
  at API 35. `dlopen`ing the (already-resident) library by soname and `dlsym`ing
  that handle resolves both while keeping the reference runtime-only.
- **`JNI_GetCreatedJavaVMs` is best-effort (API 31+).** It became a public
  `libnativehelper` export only in Android 12 (`introduced=S`). On API 24–30 a
  non-SDL host falls through to the `RuntimeError`; that is acceptable because the
  SDL path (tiers 1–2) already covers the real target on all API levels.
- **Java glue is the packager's job.** A `.whl` carries no `.dex`, and a class in
  `site-packages` is not on ART's classpath, so the wheel cannot deliver
  `org.jnius.NativeInvocationHandler` (needed only for `PythonJavaClass` proxies).
  The host build system compiles + dexes it from the canonical source that still
  lives in the repo (`jnius/src/org/jnius/NativeInvocationHandler.java`). The
  native `invoke0` contract and that source are a **matched pair** that must move
  together — documented in `android-wheel.rst`.

## Relationship to prior work

This complements, rather than duplicates, earlier Android-JNIEnv efforts:

- **#732** (`add support to android jvm on termux`, open) and its root issue
  **#247** extend `jnius/jnius_jvm_dlopen.pxi` — the *create/attach-a-VM* path —
  so a **non-SDL** host (termux) can supply a `JNIEnv`. This PR is scoped to
  `jnius/jnius_jvm_android.pxi` — the **SDL-host** path used by
  python-for-android / Kivy — making it SDL-generation-agnostic and adding an
  SDL-independent fallback. Different entry points, same overall goal of
  decoupling the Android `JNIEnv` from a hard SDL link.
- **#541** (`Refactor of env.py`, closed) left Android as an explicit TODO; the
  one-line `get_libraries()` change here is the Android-specific piece for the
  wheel use case.
- The long-dormant `android_jnienv_option` and `dlopen` branches (2014–2015,
  pre-PR-workflow direct pushes) were early sketches of the same "make the Android
  JNIEnv injectable / dlopen-based" idea; this PR carries that intent forward with
  runtime resolution and empirical on-device validation.

Happy to adjust the mechanism if the maintainers would prefer this folded into
`jnius_jvm_dlopen.pxi` alongside #732 instead of the SDL-host `.pxi`.

## Validation

- **cibuildwheel testbed (x86_64 emulator, no SDL):** `autoclass('java.lang.System')`
  round-trips via the **tier-3** `dlopen(libnativehelper)` fallback → `vm.name=Dalvik`.
- **Real SDL2 host (buildozer/p4a Kivy app, API-32 x86_64 emulator):** resolves
  via **tier 2** (`SDL_AndroidGetJNIEnv`); `PythonJavaClass` proxies (`Comparator`,
  `Runnable`) fire `invoke0` on-device; the upstream `ANDROID_ARGUMENT`
  thread-detach hook fires; `jnius_config.vm_running` stays `False` (attaches to
  the host VM, never calls `JNI_CreateJavaVM`).
- **Real arm64 hardware (Pixel 8a, Android 16 / API 36):** all of the above pass;
  ELF is clean (no `libSDL`/`libnativehelper` `DT_NEEDED`, `dlopen`/`dlsym` only,
  `0x4000` LOAD alignment).
- **kivyforge production pipeline (Pixel 8a, API 36):**
  - SDL2 (`pyjnius-deviceinfo`): contract smoke test
    (`EXT_OK` / `PROXY_OK` / `KIVY_CONTRACT_OK` / `SELFTEST_ALL_OK`) and
    `autoclass` device-info reads (`DEVICEINFO_OK`).
  - SDL3 (`hello-sdl3`, Kivy 3.0.0.dev0): same contract markers; instrumented
    build confirmed **tier 1** (`SDL_GetAndroidJNIEnv` from `libSDL3.so`) —
    not a silent tier-3 fallback.
- **Desktop (Linux, Java 17):** `build_ext` + `import jnius` + `autoclass` + a
  `Comparator` proxy round-trip all pass — the `setup.py` guards are no-ops on the
  desktop path.

**All three resolver tiers are empirically confirmed on real arm64 hardware.**

## Maintainer action required

The `publish` job uses [PyPI trusted publishing](https://docs.pypi.org/trusted-publishers/)
(OIDC), which needs a one-time trusted-publisher configured for this repo +
the `pypi` environment. Until then the build/test matrix runs but publishing is
skipped (it only triggers on a GitHub release).

## Backwards compatibility

- Desktop: unchanged (still self-hosts a JVM, still bundles the `.class`).
- Existing python-for-android SDL2 apps: unchanged behavior — the SDL2 getter is
  still used (now via runtime resolution instead of a link-time symbol).